### PR TITLE
Allow setting an optional EndToEndId

### DIFF
--- a/lib/Digitick/Sepa/TransferInformation/CustomerCreditTransferInformation.php
+++ b/lib/Digitick/Sepa/TransferInformation/CustomerCreditTransferInformation.php
@@ -28,12 +28,17 @@ class CustomerCreditTransferInformation extends BaseTransferInformation
      * @param string $amount
      * @param string $iban
      * @param string $name
+     * @param string $identification
      */
-    function __construct($amount, $iban, $name)
+    public function __construct($amount, $iban, $name, $identification = null)
     {
         parent::__construct($amount, $iban, $name);
-        // FIXME broken implementation find suitable IDs
-        $this->setEndToEndIdentification($name);
+
+        if (null === $identification) {
+            $identification = $name;
+        }
+
+        $this->setEndToEndIdentification($identification);
     }
 
     /**

--- a/tests/CustomerCreditTransferInformationTest.php
+++ b/tests/CustomerCreditTransferInformationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests;
+
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
+
+class CustomerCreditTransferInformationTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Tests whether the EndToEndId equals the name if no other identifier was supplied
+     */
+    public function testEndToEndIndentifierEqualsName()
+    {
+        $information = new CustomerCreditTransferInformation(100, 'DE12500105170648489890', 'Their Corp');
+        $this->assertEquals('Their Corp', $information->getEndToEndIdentification());
+    }
+
+    /**
+     * Tests whether the EndToEndId equals the supplied EndToEndId
+     */
+    public function testOptionalEndToEndIdentifier()
+    {
+        $information = new CustomerCreditTransferInformation(100, 'DE12500105170648489890', 'Their Corp', 'MyEndToEndId');
+        $this->assertEquals('MyEndToEndId', $information->getEndToEndIdentification());
+    }
+
+}


### PR DESCRIPTION
With this change it is possible to specify an explicit EndToEndId. The
change does not interfere with existing implementations.
