### PR TITLE
Fixed: Custom EndToEndId in DirectDebits

### DIFF
--- a/lib/Digitick/Sepa/TransferInformation/CustomerDirectDebitTransferInformation.php
+++ b/lib/Digitick/Sepa/TransferInformation/CustomerDirectDebitTransferInformation.php
@@ -45,12 +45,17 @@ class CustomerDirectDebitTransferInformation extends BaseTransferInformation
      * @param string $amount
      * @param string $iban
      * @param string $name
+     * @param string $identification
      */
-    function __construct($amount, $iban, $name)
+    public function __construct($amount, $iban, $name, $identification = null)
     {
         parent::__construct($amount, $iban, $name);
-        // FIXME broken implementation find suitable IDs
-        $this->setEndToEndIdentification($name);
+
+        if (null === $identification) {
+            $identification = $name;
+        }
+
+        $this->setEndToEndIdentification($identification);
     }
 
     /**

--- a/tests/CustomerDirectDebitTransferInformationTest.php
+++ b/tests/CustomerDirectDebitTransferInformationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests;
+
+use Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation;
+
+class CustomerDirectDebitTransferInformationTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Tests whether the EndToEndId equals the name if no other identifier was supplied
+     */
+    public function testEndToEndIndentifierEqualsName()
+    {
+        $information = new CustomerDirectDebitTransferInformation(100, 'DE12500105170648489890', 'Their Corp');
+        $this->assertEquals('Their Corp', $information->getEndToEndIdentification());
+    }
+
+    /**
+     * Tests whether the EndToEndId equals the supplied EndToEndId
+     */
+    public function testOptionalEndToEndIdentifier()
+    {
+        $information = new CustomerDirectDebitTransferInformation(100, 'DE12500105170648489890', 'Their Corp', 'MyEndToEndId');
+        $this->assertEquals('MyEndToEndId', $information->getEndToEndIdentification());
+    }
+
+}


### PR DESCRIPTION
Stumbled upon the same code in another class which was previously fixed with 7a2137fbc7cea7ac5d70678c87834ef7a61cb823
