### PR TITLE
Added amendments support.

### DIFF
--- a/lib/Digitick/Sepa/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -30,7 +30,6 @@ use Digitick\Sepa\PaymentInformation;
 use Digitick\Sepa\TransferFile\TransferFileInterface;
 use Digitick\Sepa\GroupHeader;
 
-
 class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
 {
 
@@ -173,35 +172,67 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
         $directDebitTransactionInformation->appendChild(
             $this->getRemittenceElement($transactionInformation->getRemittanceInformation())
         );
+
+        if ($transactionInformation->hasAmendments()) {
+            $amendmentIndicator = $this->createElement('AmdmntInd', 'true');
+            $mandateRelatedInformation->appendChild($amendmentIndicator);
+
+            $amendmentInformationDetails = $this->createElement('AmdmntInfDtls');
+
+            if ($transactionInformation->hasAmendedDebtorAgent()) {
+                $originalDebtorAgent = $this->createElement('OrgnlDbtrAgt');
+                $financialInstitutionIdentification = $this->createElement('FinInstnId');
+                $other = $this->createElement('Othr');
+                $id = $this->createElement('Id', 'SMNDA');
+
+                $other->appendChild($id);
+                $financialInstitutionIdentification->appendChild($other);
+                $originalDebtorAgent->appendChild($financialInstitutionIdentification);
+                $amendmentInformationDetails->appendChild($originalDebtorAgent);
+            }
+
+            if ($transactionInformation->getOriginalDebtorIban() !== null) {
+                $originalDebtorAccount = $this->createElement('OrgnlDbtrAcct');
+                $originalDebtorAccount->appendChild($this->getIbanElement($transactionInformation->getOriginalDebtorIban()));
+                $amendmentInformationDetails->appendChild($originalDebtorAccount);
+            }
+
+            if ($transactionInformation->getOriginalMandateId() !== null) {
+                $originalMandateId = $this->createElement('OrgnlMndtId', $transactionInformation->getOriginalMandateId());
+                $amendmentInformationDetails->appendChild($originalMandateId);
+            }
+
+            $mandateRelatedInformation->appendChild($amendmentInformationDetails);
+        }
+
         $this->currentPayment->appendChild($directDebitTransactionInformation);
 
     }
 
 
-	/**
-	 * Add the specific OrgId element for the format 'pain.008.001.02'
-	 *
-	 * @param  GroupHeader $groupHeader
-	 * @return mixed
-	 */
-	public function visitGroupHeader(GroupHeader $groupHeader)
-	{
-		parent::visitGroupHeader($groupHeader);
+    /**
+     * Add the specific OrgId element for the format 'pain.008.001.02'
+     *
+     * @param  GroupHeader $groupHeader
+     * @return mixed
+     */
+    public function visitGroupHeader(GroupHeader $groupHeader)
+    {
+        parent::visitGroupHeader($groupHeader);
 
-		if ($groupHeader->getInitiatingPartyId() !== null && $this->painFormat === 'pain.008.001.02') {
-			$newId = $this->createElement('Id');
-			$orgId = $this->createElement('OrgId');
-			$othr  = $this->createElement('Othr');
-			$othr->appendChild($this->createElement('Id', $groupHeader->getInitiatingPartyId()));
-			$orgId->appendChild($othr);
-			$newId->appendChild($orgId);
+        if ($groupHeader->getInitiatingPartyId() !== null && $this->painFormat === 'pain.008.001.02') {
+            $newId = $this->createElement('Id');
+            $orgId = $this->createElement('OrgId');
+            $othr  = $this->createElement('Othr');
+            $othr->appendChild($this->createElement('Id', $groupHeader->getInitiatingPartyId()));
+            $orgId->appendChild($othr);
+            $newId->appendChild($orgId);
 
-			$xpath = new \DOMXpath($this->doc);
-			$items = $xpath->query('GrpHdr/InitgPty/Id', $this->currentTransfer);
-			$oldId = $items->item(0);
+            $xpath = new \DOMXpath($this->doc);
+            $items = $xpath->query('GrpHdr/InitgPty/Id', $this->currentTransfer);
+            $oldId = $items->item(0);
 
-			$oldId->parentNode->replaceChild($newId, $oldId);
-		}
-	}
-
+            $oldId->parentNode->replaceChild($newId, $oldId);
+        }
+    }
 }

--- a/lib/Digitick/Sepa/TransferFile/Facade/CustomerDirectDebitFacade.php
+++ b/lib/Digitick/Sepa/TransferFile/Facade/CustomerDirectDebitFacade.php
@@ -83,6 +83,7 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
      *      - debtorMandateSignDate
      *      - remittanceInformation
      *      - [endToEndId]
+     *      - [amendments]
      *
      * @throws \Digitick\Sepa\Exception\InvalidArgumentException
      * @return mixed
@@ -114,6 +115,15 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
             $transfer->setEndToEndIdentification(
                 $this->payments[$paymentName]->getId() . count($this->payments[$paymentName]->getTransfers())
             );
+        }
+        if (isset($transferInformation['originalMandateId'])) {
+            $transfer->setOriginalMandateId($transferInformation['originalMandateId']);
+        }
+        if (isset($transferInformation['originalDebtorIban'])) {
+            $transfer->setOriginalDebtorIban($transferInformation['originalDebtorIban']);
+        }
+        if (isset($transferInformation['amendedDebtorAgent'])) {
+            $transfer->setAmendedDebtorAgent((bool)$transferInformation['amendedDebtorAgent']);
         }
 
         $this->payments[$paymentName]->addTransfer($transfer);

--- a/lib/Digitick/Sepa/TransferInformation/CustomerDirectDebitTransferInformation.php
+++ b/lib/Digitick/Sepa/TransferInformation/CustomerDirectDebitTransferInformation.php
@@ -42,6 +42,21 @@ class CustomerDirectDebitTransferInformation extends BaseTransferInformation
     protected $finalCollectionDate;
 
     /**
+     * @var bool
+     */
+    protected $amendedDebtorAgent = false;
+
+    /**
+     * @var string|null
+     */
+    protected $originalDebtorIban = null;
+
+    /**
+     * @var string|null
+     */
+    protected $originalMandateId = null;
+
+    /**
      * @param string $amount
      * @param string $iban
      * @param string $name
@@ -59,6 +74,32 @@ class CustomerDirectDebitTransferInformation extends BaseTransferInformation
     }
 
     /**
+     * @return boolean
+     */
+    public function hasAmendments()
+    {
+        return $this->amendedDebtorAgent
+            || $this->originalDebtorIban !== null
+            || $this->originalMandateId !== null;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function hasAmendedDebtorAgent()
+    {
+        return $this->amendedDebtorAgent;
+    }
+
+    /**
+     * @param bool $status
+     */
+    public function setAmendedDebtorAgent($status)
+    {
+        $this->amendedDebtorAgent = $status;
+    }
+
+    /**
      * @param \DateTime $finalCollectionDate
      */
     public function setFinalCollectionDate($finalCollectionDate)
@@ -72,6 +113,38 @@ class CustomerDirectDebitTransferInformation extends BaseTransferInformation
     public function getFinalCollectionDate()
     {
         return $this->finalCollectionDate;
+    }
+
+    /**
+     * @param string $originalDebtorIban
+     */
+    public function setOriginalDebtorIban($originalDebtorIban)
+    {
+        $this->originalDebtorIban = $originalDebtorIban;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOriginalDebtorIban()
+    {
+        return $this->originalDebtorIban;
+    }
+
+    /**
+     * @param string $originalMandateId
+     */
+    public function setOriginalMandateId($originalMandateId)
+    {
+        $this->originalMandateId = StringHelper::sanitizeString($originalMandateId);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOriginalMandateId()
+    {
+        return $this->originalMandateId;
     }
 
     /**
@@ -113,6 +186,4 @@ class CustomerDirectDebitTransferInformation extends BaseTransferInformation
     {
         return $this->name;
     }
-
-
 }


### PR DESCRIPTION
Hi,

This pull requests adds support for amendments. Currently it supports amendments in mandate id, debtor account and debtor agent, but can easily be extended to support more amendments.

Usage:

```php
// Add a Single Transaction to the named payment
$directDebit->addTransfer('firstPayment', array(
    'amount'                => '500',
    'debtorIban'            => 'FI1350001540000056',
    'debtorBic'             => 'OKOYFIHH',
    'debtorName'            => 'Their Company',
    'debtorMandate'         => 'AB12345',
    'debtorMandateSignDate' => '13.10.2012',
    'remittanceInformation' => 'Purpose of this direct debit',
    // Amendments start here
    'originalMandateId'     => '1234567890',
    'originalDebtorIban'    => 'AT711100015440033700',
    'amendedDebtorAgent'    => true
));
```

Greetings,
Jarno