### PR TITLE
Add: Missing CustomerCreditFacade

### DIFF
--- a/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -23,15 +23,23 @@
 namespace Digitick\Sepa\DomBuilder;
 
 use Digitick\Sepa\PaymentInformation;
-use Digitick\Sepa\TransferFile\CustomerCreditTransferFile;
 use Digitick\Sepa\TransferFile\TransferFileInterface;
 use Digitick\Sepa\GroupHeader;
 use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
 use Digitick\Sepa\TransferInformation\TransferInformationInterface;
 
+/**
+ * Class CustomerCreditTransferDomBuilder
+ */
 class CustomerCreditTransferDomBuilder extends BaseDomBuilder
 {
-    public function __construct($painFormat = 'pain.001.002.03')
+
+    /**
+     * CustomerCreditTransferDomBuilder constructor
+     *
+     * @param string $painFormat
+     */
+    function __construct($painFormat = 'pain.001.003.03')
     {
         parent::__construct($painFormat);
     }

--- a/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -39,7 +39,7 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
      *
      * @param string $painFormat
      */
-    function __construct($painFormat = 'pain.001.003.03')
+    function __construct($painFormat = 'pain.001.002.03')
     {
         parent::__construct($painFormat);
     }

--- a/lib/Digitick/Sepa/TransferFile/Facade/CustomerCreditFacade.php
+++ b/lib/Digitick/Sepa/TransferFile/Facade/CustomerCreditFacade.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Digitick\Sepa\TransferFile\Facade;
+
+use Digitick\Sepa\Exception\InvalidArgumentException;
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
+
+/**
+ * Class CustomerCreditFacade
+ */
+class CustomerCreditFacade extends BaseCustomerTransferFileFacade
+{
+
+    /**
+     * @param string $paymentName
+     * @param array  $paymentInformation
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return PaymentInformation
+     */
+    public function addPaymentInfo($paymentName, array $paymentInformation)
+    {
+        if (isset($this->payments[$paymentName])) {
+            throw new InvalidArgumentException(sprintf('Payment with the name %s already exists', $paymentName));
+        }
+
+        $payment = new PaymentInformation(
+            $paymentInformation['id'],
+            $paymentInformation['debtorAccountIBAN'],
+            $paymentInformation['debtorAgentBIC'],
+            $paymentInformation['debtorName']
+        );
+
+        $this->payments[$paymentName] = $payment;
+
+        return $payment;
+    }
+
+    /**
+     * @param string $paymentName
+     * @param array  $transferInformation
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return CustomerCreditTransferInformation
+     */
+    public function addTransfer($paymentName, array $transferInformation)
+    {
+        if (!isset($this->payments[$paymentName])) {
+            throw new InvalidArgumentException(sprintf(
+                'Payment with the name %s does not exists, create one first with addPaymentInfo',
+                $paymentName
+            ));
+        }
+
+        $transfer = new CustomerCreditTransferInformation(
+            $transferInformation['amount'],
+            $transferInformation['creditorIban'],
+            $transferInformation['creditorName']
+        );
+        $transfer->setBic($transferInformation['creditorBic']);
+        $transfer->setRemittanceInformation($transferInformation['remittanceInformation']);
+
+        if (isset($transferInformation['endToEndId'])) {
+            $transfer->setEndToEndIdentification($transferInformation['endToEndId']);
+        } else {
+            $transfer->setEndToEndIdentification(
+                $this->payments[$paymentName]->getId() . count($this->payments[$paymentName]->getTransfers())
+            );
+        }
+
+        $this->payments[$paymentName]->addTransfer($transfer);
+
+        return $transfer;
+    }
+
+}

--- a/lib/Digitick/Sepa/TransferFile/Factory/TransferFileFacadeFactory.php
+++ b/lib/Digitick/Sepa/TransferFile/Factory/TransferFileFacadeFactory.php
@@ -26,6 +26,7 @@ use Digitick\Sepa\DomBuilder\CustomerCreditTransferDomBuilder;
 use Digitick\Sepa\DomBuilder\CustomerDirectDebitTransferDomBuilder;
 use Digitick\Sepa\GroupHeader;
 use Digitick\Sepa\TransferFile\CustomerCreditTransferFile;
+use Digitick\Sepa\TransferFile\Facade\CustomerCreditFacade;
 use Digitick\Sepa\TransferFile\Facade\CustomerDirectDebitFacade;
 use Digitick\Sepa\TransferFile\CustomerDirectDebitTransferFile;
 
@@ -66,7 +67,7 @@ class TransferFileFacadeFactory
      *
      * @return CustomerCreditFacade
      */
-    public static function createCustomerCredit($uniqueMessageIdentification, $initiatingPartyName, $painFormat = 'pain.001.002.03')
+    public static function createCustomerCredit($uniqueMessageIdentification, $initiatingPartyName, $painFormat = 'pain.001.003.03')
     {
         $groupHeader = new GroupHeader($uniqueMessageIdentification, $initiatingPartyName);
 

--- a/lib/Digitick/Sepa/TransferFile/Factory/TransferFileFacadeFactory.php
+++ b/lib/Digitick/Sepa/TransferFile/Factory/TransferFileFacadeFactory.php
@@ -67,7 +67,7 @@ class TransferFileFacadeFactory
      *
      * @return CustomerCreditFacade
      */
-    public static function createCustomerCredit($uniqueMessageIdentification, $initiatingPartyName, $painFormat = 'pain.001.003.03')
+    public static function createCustomerCredit($uniqueMessageIdentification, $initiatingPartyName, $painFormat = 'pain.001.002.03')
     {
         $groupHeader = new GroupHeader($uniqueMessageIdentification, $initiatingPartyName);
 

--- a/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
+++ b/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
@@ -65,7 +65,7 @@ class BaseTransferInformation implements TransferInformationInterface
     protected $EndToEndIdentification;
 
     /**
-     * @var
+     * @var string
      */
     protected $currency = 'EUR';
 
@@ -80,6 +80,8 @@ class BaseTransferInformation implements TransferInformationInterface
      * @param string $amount
      * @param string $iban
      * @param string $name
+     *
+     * @throws InvalidArgumentException
      */
     public function __construct($amount, $iban, $name)
     {
@@ -208,4 +210,5 @@ class BaseTransferInformation implements TransferInformationInterface
     {
         return $this->remittanceInformation;
     }
+
 }

--- a/tests/CustomerCreditFacadeTest.php
+++ b/tests/CustomerCreditFacadeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests;
+
+use Digitick\Sepa\TransferFile\Factory\TransferFileFacadeFactory;
+
+/**
+ * Class CustomerCreditFacadeTest
+ */
+class CustomerCreditFacadeTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var string
+     */
+    protected $schema;
+
+    /**
+     * @var \DOMDocument
+     */
+    protected $dom;
+
+    /**
+     * Setup
+     */
+    protected function setUp()
+    {
+        $this->schema = __DIR__ . "/pain.001.003.03.xsd";
+        $this->dom = new \DOMDocument('1.0', 'UTF-8');
+    }
+
+    /**
+     * Test creation of file via Factory and Facade
+     */
+    public function testValidFileCreationWithFacade()
+    {
+        $credit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me');
+        $credit->addPaymentInfo(
+            'firstPayment',
+            array(
+                'id' => 'firstPayment',
+                'debtorName' => 'My Company',
+                'debtorAccountIBAN' => 'FI1350001540000056',
+                'debtorAgentBIC' => 'PSSTFRPPMON'
+            )
+        );
+        $credit->addTransfer(
+            'firstPayment',
+            array(
+                'amount' => '500',
+                'creditorIban' => 'FI1350001540000056',
+                'creditorBic' => 'OKOYFIHH',
+                'creditorName' => 'Their Company',
+                'remittanceInformation' => 'Purpose of this credit'
+            )
+        );
+
+        $this->dom->loadXML($credit->asXML());
+        $this->assertTrue($this->dom->schemaValidate($this->schema));
+    }
+}

--- a/tests/CustomerCreditFacadeTest.php
+++ b/tests/CustomerCreditFacadeTest.php
@@ -51,10 +51,10 @@ class CustomerCreditFacadeTest extends \PHPUnit_Framework_TestCase
      */
     public function schemaProvider()
     {
-        return [
-            ["pain.001.001.03"],
-            ["pain.001.002.03"],
-            ["pain.001.003.03"]
-        ];
+        return array(
+            array("pain.001.001.03"),
+            array("pain.001.002.03"),
+            array("pain.001.003.03")
+        );
     }
 }

--- a/tests/CustomerCreditFacadeTest.php
+++ b/tests/CustomerCreditFacadeTest.php
@@ -11,30 +11,17 @@ class CustomerCreditFacadeTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
-     * @var string
-     */
-    protected $schema;
-
-    /**
-     * @var \DOMDocument
-     */
-    protected $dom;
-
-    /**
-     * Setup
-     */
-    protected function setUp()
-    {
-        $this->schema = __DIR__ . "/pain.001.003.03.xsd";
-        $this->dom = new \DOMDocument('1.0', 'UTF-8');
-    }
-
-    /**
      * Test creation of file via Factory and Facade
+     *
+     * @param string $schema
+     *
+     * @dataProvider schemaProvider
      */
-    public function testValidFileCreationWithFacade()
+    public function testValidFileCreationWithFacade($schema)
     {
-        $credit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me');
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+
+        $credit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me', $schema);
         $credit->addPaymentInfo(
             'firstPayment',
             array(
@@ -55,7 +42,19 @@ class CustomerCreditFacadeTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $this->dom->loadXML($credit->asXML());
-        $this->assertTrue($this->dom->schemaValidate($this->schema));
+        $dom->loadXML($credit->asXML());
+        $this->assertTrue($dom->schemaValidate(__DIR__ . "/" . $schema . ".xsd"));
+    }
+
+    /**
+     * @return array
+     */
+    public function schemaProvider()
+    {
+        return [
+            ["pain.001.001.03"],
+            ["pain.001.002.03"],
+            ["pain.001.003.03"]
+        ];
     }
 }

--- a/tests/CustomerCreditValidationTest.php
+++ b/tests/CustomerCreditValidationTest.php
@@ -49,7 +49,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->schema = __DIR__ . "/pain.001.003.03.xsd";
+        $this->schema = __DIR__ . "/pain.001.002.03.xsd";
         $this->dom = new \DOMDocument('1.0', 'UTF-8');
     }
 
@@ -58,7 +58,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
      */
     public function testSanity()
     {
-        $this->dom->load(__DIR__ . '/pain.001.003.03.xml');
+        $this->dom->load(__DIR__ . '/pain.001.002.03.xml');
         $validated = $this->dom->schemaValidate($this->schema);
         $this->assertTrue($validated);
     }
@@ -166,7 +166,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $doc->loadXML($xml);
 
         $xpathDoc = new \DOMXPath($doc);
-        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03');
+        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.002.03');
         $numberOfTxs = $xpathDoc->query('//sepa:NbOfTxs');
         $this->assertEquals(2, $numberOfTxs->item(0)->textContent);
         $ctrlSum = $xpathDoc->query('//sepa:CtrlSum');
@@ -197,7 +197,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $doc->loadXML($xml);
 
         $xpathDoc = new \DOMXPath($doc);
-        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03');
+        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.002.03');
         // Date is correctly coded
         $executionDate = $xpathDoc->query('//sepa:ReqdExctnDt');
         $this->assertEquals('2012-11-20', $executionDate->item(0)->textContent);
@@ -261,7 +261,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($validated);
 
         $xpathDoc = new \DOMXPath($this->dom);
-        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03');
+        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.002.03');
         $numberOfTxs = $xpathDoc->query('//sepa:NbOfTxs');
         $this->assertEquals(4, $numberOfTxs->item(0)->textContent);
         $this->assertEquals(2, $numberOfTxs->item(1)->textContent);
@@ -297,7 +297,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $doc->loadXML($xml);
 
         $xpathDoc = new \DOMXPath($doc);
-        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03');
+        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.002.03');
         // Date is correctly coded
         $testNode = $xpathDoc->query('//sepa:InitgPty/sepa:Nm');
         $this->assertEquals('Only A-Z without aeoeuessAeOeUe initiatingPartyName', $testNode->item(0)->textContent);
@@ -347,7 +347,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $doc->loadXML($xml);
 
         $xpathDoc = new \DOMXPath($doc);
-        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03');
+        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.002.03');
 
         $testNode = $xpathDoc->query('//sepa:CreDtTm');
         $this->assertEquals($dateTime->format($dateTimeFormat), $testNode->item(0)->textContent, 'CreDtTm should have the specified format: ' . $dateTimeFormat);

--- a/tests/CustomerCreditValidationTest.php
+++ b/tests/CustomerCreditValidationTest.php
@@ -33,6 +33,10 @@ use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
  */
 class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
 {
+
+    /**
+     * @var string
+     */
     protected $schema;
 
     /**
@@ -40,9 +44,12 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
      */
     protected $dom;
 
+    /**
+     * Setup
+     */
     protected function setUp()
     {
-        $this->schema = __DIR__ . "/pain.001.002.03.xsd";
+        $this->schema = __DIR__ . "/pain.001.003.03.xsd";
         $this->dom = new \DOMDocument('1.0', 'UTF-8');
     }
 
@@ -51,7 +58,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
      */
     public function testSanity()
     {
-        $this->dom->load(__DIR__ . '/pain.001.002.03.xml');
+        $this->dom->load(__DIR__ . '/pain.001.003.03.xml');
         $validated = $this->dom->schemaValidate($this->schema);
         $this->assertTrue($validated);
     }
@@ -159,7 +166,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $doc->loadXML($xml);
 
         $xpathDoc = new \DOMXPath($doc);
-        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.002.03');
+        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03');
         $numberOfTxs = $xpathDoc->query('//sepa:NbOfTxs');
         $this->assertEquals(2, $numberOfTxs->item(0)->textContent);
         $ctrlSum = $xpathDoc->query('//sepa:CtrlSum');
@@ -190,7 +197,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $doc->loadXML($xml);
 
         $xpathDoc = new \DOMXPath($doc);
-        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.002.03');
+        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03');
         // Date is correctly coded
         $executionDate = $xpathDoc->query('//sepa:ReqdExctnDt');
         $this->assertEquals('2012-11-20', $executionDate->item(0)->textContent);
@@ -254,7 +261,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($validated);
 
         $xpathDoc = new \DOMXPath($this->dom);
-        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.002.03');
+        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03');
         $numberOfTxs = $xpathDoc->query('//sepa:NbOfTxs');
         $this->assertEquals(4, $numberOfTxs->item(0)->textContent);
         $this->assertEquals(2, $numberOfTxs->item(1)->textContent);
@@ -290,7 +297,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $doc->loadXML($xml);
 
         $xpathDoc = new \DOMXPath($doc);
-        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.002.03');
+        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03');
         // Date is correctly coded
         $testNode = $xpathDoc->query('//sepa:InitgPty/sepa:Nm');
         $this->assertEquals('Only A-Z without aeoeuessAeOeUe initiatingPartyName', $testNode->item(0)->textContent);
@@ -340,7 +347,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $doc->loadXML($xml);
 
         $xpathDoc = new \DOMXPath($doc);
-        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.002.03');
+        $xpathDoc->registerNamespace('sepa', 'urn:iso:std:iso:20022:tech:xsd:pain.001.003.03');
 
         $testNode = $xpathDoc->query('//sepa:CreDtTm');
         $this->assertEquals($dateTime->format($dateTimeFormat), $testNode->item(0)->textContent, 'CreDtTm should have the specified format: ' . $dateTimeFormat);

--- a/tests/pain.001.003.03.xml
+++ b/tests/pain.001.003.03.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Mit XMLSpy v2008 rel. 2 sp2 (http://www.altova.com) von benutzerservice benutzerservice (SIZ GmbH) bearbeitet -->
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.003.03" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:pain.001.003.03 pain.001.003.03.xsd">
+	<CstmrCdtTrfInitn>
+		<GrpHdr>
+			<MsgId>Message-ID-4711</MsgId>
+			<CreDtTm>2010-11-11T09:30:47.000Z</CreDtTm>
+			<NbOfTxs>2</NbOfTxs>
+			<InitgPty>
+				<Nm>Initiator Name</Nm>
+			</InitgPty>
+		</GrpHdr>
+		<PmtInf>
+			<PmtInfId>Payment-Information-ID-4711</PmtInfId>
+			<PmtMtd>TRF</PmtMtd>
+			<BtchBookg>true</BtchBookg>
+			<NbOfTxs>2</NbOfTxs>
+			<CtrlSum>6655.86</CtrlSum>
+			<PmtTpInf>
+				<SvcLvl>
+					<Cd>SEPA</Cd>
+				</SvcLvl>
+			</PmtTpInf>
+			<ReqdExctnDt>2010-11-25</ReqdExctnDt>
+			<Dbtr>
+				<Nm>Debtor Name</Nm>
+			</Dbtr>
+			<DbtrAcct>
+				<Id>
+					<IBAN>DE87200500001234567890</IBAN>
+				</Id>
+			</DbtrAcct>
+			<DbtrAgt>
+				<FinInstnId>
+					<BIC>BANKDEFFXXX</BIC>
+				</FinInstnId>
+			</DbtrAgt>
+			<ChrgBr>SLEV</ChrgBr>
+			<CdtTrfTxInf>
+				<PmtId>
+					<EndToEndId>OriginatorID1234</EndToEndId>
+				</PmtId>
+				<Amt>
+					<InstdAmt Ccy="EUR">6543.14</InstdAmt>
+				</Amt>
+				<CdtrAgt>
+					<FinInstnId>
+						<BIC>SPUEDE2UXXX</BIC>
+					</FinInstnId>
+				</CdtrAgt>
+				<Cdtr>
+					<Nm>Creditor Name</Nm>
+				</Cdtr>
+				<CdtrAcct>
+					<Id>
+						<IBAN>DE21500500009876543210</IBAN>
+					</Id>
+				</CdtrAcct>
+				<RmtInf>
+					<Ustrd>Unstructured Remittance Information</Ustrd>
+				</RmtInf>
+			</CdtTrfTxInf>
+			<CdtTrfTxInf>
+				<PmtId>
+					<EndToEndId>OriginatorID1235</EndToEndId>
+				</PmtId>
+				<Amt>
+					<InstdAmt Ccy="EUR">112.72</InstdAmt>
+				</Amt>
+				<CdtrAgt>
+					<FinInstnId>
+						<BIC>SPUEDE2UXXX</BIC>
+					</FinInstnId>
+				</CdtrAgt>
+				<Cdtr>
+					<Nm>Other Creditor Name</Nm>
+				</Cdtr>
+				<CdtrAcct>
+					<Id>
+						<IBAN>DE21500500001234567897</IBAN>
+					</Id>
+				</CdtrAcct>
+				<RmtInf>
+					<Ustrd>Unstructured Remittance Information</Ustrd>
+				</RmtInf>
+			</CdtTrfTxInf>
+		</PmtInf>
+	</CstmrCdtTrfInitn>
+</Document>

--- a/tests/pain.001.003.03.xsd
+++ b/tests/pain.001.003.03.xsd
@@ -1,0 +1,474 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Version gemäß DFÜ-Abkommen Anlage 3, Version 2.7, gültig ab November 2013 mit Umsetzung von IBAN Only gemäß EPC SCT 7.0, zudem Erweiterung Service Level auf Externe Codeliste-->
+<!-- Mit XMLSpy v2008 am 29.11.2012 von der SIZ GmbH bearbeitet -->
+<xs:schema xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.003.03" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:iso:std:iso:20022:tech:xsd:pain.001.003.03" elementFormDefault="qualified">
+	<xs:element name="Document" type="Document"/>
+	<xs:complexType name="AccountIdentificationSEPA">
+		<xs:sequence>
+			<xs:element name="IBAN" type="IBAN2007Identifier"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyAndAmount_SimpleTypeSEPA">
+		<xs:restriction base="xs:decimal">
+			<xs:minInclusive value="0.01"/>
+			<xs:maxInclusive value="999999999.99"/>
+			<xs:fractionDigits value="2"/>
+			<xs:totalDigits value="11"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{3,3}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ActiveOrHistoricCurrencyAndAmountSEPA">
+		<xs:simpleContent>
+			<xs:extension base="ActiveOrHistoricCurrencyAndAmount_SimpleTypeSEPA">
+				<xs:attribute name="Ccy" type="ActiveOrHistoricCurrencyCodeEUR" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyCodeEUR">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EUR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AmountTypeSEPA">
+		<xs:sequence>
+			<xs:element name="InstdAmt" type="ActiveOrHistoricCurrencyAndAmountSEPA"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="AnyBICIdentifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BICIdentifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BatchBookingIndicator">
+		<xs:restriction base="xs:boolean"/>
+	</xs:simpleType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentificationSEPA1">
+		<xs:sequence>
+			<xs:element name="FinInstnId" type="FinancialInstitutionIdentificationSEPA1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentificationSEPA3">
+		<xs:sequence>
+			<xs:element name="FinInstnId" type="FinancialInstitutionIdentificationSEPA3"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CashAccountSEPA1">
+		<xs:sequence>
+			<xs:element name="Id" type="AccountIdentificationSEPA"/>
+			<xs:element name="Ccy" type="ActiveOrHistoricCurrencyCode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CashAccountSEPA2">
+		<xs:sequence>
+			<xs:element name="Id" type="AccountIdentificationSEPA"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CategoryPurposeSEPA">
+		<xs:sequence>
+			<xs:element name="Cd" type="ExternalCategoryPurpose1Code"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="ChargeBearerTypeSEPACode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SLEV"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CountryCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="CreditTransferTransactionInformationSCT">
+		<xs:sequence>
+			<xs:element name="PmtId" type="PaymentIdentificationSEPA"/>
+			<xs:element name="PmtTpInf" type="PaymentTypeInformationSCT2" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If used, it is recommended to be used at ‘Payment Information’ level and not at ‘Credit Transfer Transaction Information’ level.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Amt" type="AmountTypeSEPA"/>
+			<xs:element name="ChrgBr" type="ChargeBearerTypeSEPACode" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>It is recommended that this element be specified at ‘Payment Information’ level.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="UltmtDbtr" type="PartyIdentificationSEPA1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>This data element may be present either at ‘Payment Information’ or at ‘Credit Transfer Transaction Information’ level.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CdtrAgt" type="BranchAndFinancialInstitutionIdentificationSEPA1" minOccurs="0"/>
+			<xs:element name="Cdtr" type="PartyIdentificationSEPA2"/>
+			<xs:element name="CdtrAcct" type="CashAccountSEPA2"/>
+			<xs:element name="UltmtCdtr" type="PartyIdentificationSEPA1" minOccurs="0"/>
+			<xs:element name="Purp" type="PurposeSEPA" minOccurs="0"/>
+			<xs:element name="RmtInf" type="RemittanceInformationSEPA1Choice" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceInformationSEPA1">
+		<xs:sequence>
+			<xs:element name="Tp" type="CreditorReferenceTypeSEPA"/>
+			<xs:element name="Ref" type="Max35Text">
+				<xs:annotation>
+					<xs:documentation>If a Creditor Reference contains a check digit, the receiving bank is not required to validate this.
+If the receiving bank validates the check digit and if this validation fails, the bank may continue its processing and send the transaction to the next party in the chain.
+RF Creditor Reference may be used (ISO 11649).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceTypeSEPA">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="CreditorReferenceTypeCodeSEPA"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceTypeCodeSEPA">
+		<xs:sequence>
+			<xs:element name="Cd" type="DocumentType3CodeSEPA"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CustomerCreditTransferInitiationV03">
+		<xs:sequence>
+			<xs:element name="GrpHdr" type="GroupHeaderSCT"/>
+			<xs:element name="PmtInf" type="PaymentInstructionInformationSCT" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DateAndPlaceOfBirth">
+		<xs:sequence>
+			<xs:element name="BirthDt" type="ISODate"/>
+			<xs:element name="PrvcOfBirth" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CityOfBirth" type="Max35Text"/>
+			<xs:element name="CtryOfBirth" type="CountryCode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="DecimalNumber">
+		<xs:restriction base="xs:decimal">
+			<xs:fractionDigits value="17"/>
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Document">
+		<xs:sequence>
+			<xs:element name="CstmrCdtTrfInitn" type="CustomerCreditTransferInitiationV03"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="DocumentType3CodeSEPA">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SCOR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalCategoryPurpose1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalOrganisationIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalPersonIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalPurpose1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalServiceLevel1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="FinancialInstitutionIdentificationSEPA1">
+		<xs:sequence>
+			<xs:element name="BIC" type="BICIdentifier"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentificationSEPA3">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="BIC" type="BICIdentifier"/>
+				<xs:element name="Othr" type="OthrIdentification"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OthrIdentification">
+		<xs:sequence>
+			<xs:element name="Id" type="OthrIdentificationCode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="OthrIdentificationCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="NOTPROVIDED"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="GenericOrganisationIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="OrganisationIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericPersonIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="PersonIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GroupHeaderSCT">
+		<xs:sequence>
+			<xs:element name="MsgId" type="RestrictedIdentificationSEPA1"/>
+			<xs:element name="CreDtTm" type="ISODateTime"/>
+			<xs:element name="NbOfTxs" type="Max15NumericText"/>
+			<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+			<xs:element name="InitgPty" type="PartyIdentificationSEPA1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="IBAN2007Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ISODate">
+		<xs:restriction base="xs:date"/>
+	</xs:simpleType>
+	<xs:simpleType name="ISODateTime">
+		<xs:restriction base="xs:dateTime"/>
+	</xs:simpleType>
+	<xs:simpleType name="Max140Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="140"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max15NumericText">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{1,15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max35Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max70Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="70"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="OrganisationIdentificationSEPAChoice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="BICOrBEI" type="AnyBICIdentifier"/>
+				<xs:element name="Othr" type="GenericOrganisationIdentification1"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OrganisationIdentificationSchemeName1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Cd" type="ExternalOrganisationIdentification1Code"/>
+				<xs:element name="Prtry" type="Max35Text"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PartySEPAChoice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="OrgId" type="OrganisationIdentificationSEPAChoice">
+					<xs:annotation>
+						<xs:documentation>Either ‘BIC or BEI’ or one
+occurrence of ‘Other’ is allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="PrvtId" type="PersonIdentificationSEPA1Choice">
+					<xs:annotation>
+						<xs:documentation>Either ‘Date and Place of Birth’ or one occurrence of ‘Other’ is allowed.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentificationSEPA1">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max70Text" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>‘Name’ is limited to 70 characters
+in length.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Id" type="PartySEPAChoice" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentificationSEPA2">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max70Text">
+				<xs:annotation>
+					<xs:documentation>‘Name’ is limited to 70 characters
+in length.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PstlAdr" type="PostalAddressSEPA" minOccurs="0"/>
+			<xs:element name="Id" type="PartySEPAChoice" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentIdentificationSEPA">
+		<xs:sequence>
+			<xs:element name="InstrId" type="RestrictedIdentificationSEPA1" minOccurs="0"/>
+			<xs:element name="EndToEndId" type="RestrictedIdentificationSEPA1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentInstructionInformationSCT">
+		<xs:sequence>
+			<xs:element name="PmtInfId" type="RestrictedIdentificationSEPA1"/>
+			<xs:element name="PmtMtd" type="PaymentMethodSCTCode">
+				<xs:annotation>
+					<xs:documentation>Only ‘TRF’ is allowed.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BtchBookg" type="BatchBookingIndicator" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If present and contains ‘true’, batch booking is requested. If present and contains ‘false’, booking per transaction is requested. If element is not present, pre-agreed customer-to-bank conditions apply.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="NbOfTxs" type="Max15NumericText" minOccurs="0"/>
+			<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+			<xs:element name="PmtTpInf" type="PaymentTypeInformationSCT1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If used, it is recommended to be used only at ‘Payment Information’ level and not at Credit Transfer Transaction Information’ level.
+When Instruction Priority is to be used, ‘Payment Type Information’ must be present at ‘Payment Information’ level. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ReqdExctnDt" type="ISODate"/>
+			<xs:element name="Dbtr" type="PartyIdentificationSEPA2"/>
+			<xs:element name="DbtrAcct" type="CashAccountSEPA1"/>
+			<xs:element name="DbtrAgt" type="BranchAndFinancialInstitutionIdentificationSEPA3"/>
+			<xs:element name="UltmtDbtr" type="PartyIdentificationSEPA1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>This data element may be present either at ‘Payment Information’ or at ‘Credit Transfer Transaction Information’ level.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ChrgBr" type="ChargeBearerTypeSEPACode" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>It is recommended that this element be specified at ‘Payment Information’ level.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CdtTrfTxInf" type="CreditTransferTransactionInformationSCT" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="PaymentMethodSCTCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="TRF"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PaymentTypeInformationSCT1">
+		<xs:sequence>
+			<xs:element name="InstrPrty" type="Priority2Code" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If present, pre-agreed customer-to-bank conditions apply.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SvcLvl" type="ServiceLevelSEPA"/>
+			<xs:element name="CtgyPurp" type="CategoryPurposeSEPA" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Depending on the agreement between the Originator and the Originator Bank, ‘Category Purpose’ may be forwarded to the Beneficiary Bank.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentTypeInformationSCT2">
+		<xs:sequence>
+			<xs:element name="SvcLvl" type="ServiceLevelSEPA"/>
+			<xs:element name="CtgyPurp" type="CategoryPurposeSEPA" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Depending on the agreement between the Originator and the Originator Bank, ‘Category Purpose’ may be forwarded to the Beneficiary Bank.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentificationSEPA1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="DtAndPlcOfBirth" type="DateAndPlaceOfBirth"/>
+				<xs:element name="Othr" type="GenericPersonIdentification1"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentificationSchemeName1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Cd" type="ExternalPersonIdentification1Code"/>
+				<xs:element name="Prtry" type="Max35Text"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PostalAddressSEPA">
+		<xs:sequence>
+			<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+			<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="2"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="Priority2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="HIGH"/>
+			<xs:enumeration value="NORM"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PurposeSEPA">
+		<xs:sequence>
+			<xs:element name="Cd" type="ExternalPurpose1Code">
+				<xs:annotation>
+					<xs:documentation>Only codes from the ISO 20022 ExternalPurposeCode list are allowed.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceInformationSEPA1Choice">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Ustrd" type="Max140Text"/>
+				<xs:element name="Strd" type="StructuredRemittanceInformationSEPA1"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceLevelSEPA">
+		<xs:sequence>
+			<xs:element name="Cd" type="ExternalServiceLevel1Code"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructuredRemittanceInformationSEPA1">
+		<xs:sequence>
+			<xs:element name="CdtrRefInf" type="CreditorReferenceInformationSEPA1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>When present, the receiving bank is not obliged to validate the the reference information. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="RestrictedIdentificationSEPA1">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="([A-Za-z0-9]|[\+|\?|/|\-|:|\(|\)|\.|,|'| ]){1,35}"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
This should fix #14 and make the `TransferFileFacadeFactory` completely usable. I also updated the format within this change to `pain.001.003.03` and uploaded the new schemas for this format.