### PR TITLE
Tests for all schemas

### DIFF
--- a/tests/CustomerCreditValidationPain00100103Test.php
+++ b/tests/CustomerCreditValidationPain00100103Test.php
@@ -58,6 +58,7 @@ class CustomerCreditValidationPain00100103Test extends \PHPUnit_Framework_TestCa
 
     /**
      * Test a transfer file with one payment and one transaction.
+     *
      * @dataProvider scenarios
      */
     public function testSinglePaymentSingleTransWithMoreInfo($scenario)

--- a/tests/CustomerDirectDebitFacadeTest.php
+++ b/tests/CustomerDirectDebitFacadeTest.php
@@ -42,10 +42,14 @@ class CustomerDirectDebitFacadeTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test creation of file via Factory and Facade
+     *
+     * @param string $schema
+     *
+     * @dataProvider provideSchema
      */
-    public function testValidFileCreationWithFacade()
+    public function testValidFileCreationWithFacade($schema)
     {
-        $directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me');
+        $directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me', $schema);
         $directDebit->addPaymentInfo(
             'firstPayment',
             array(
@@ -71,6 +75,18 @@ class CustomerDirectDebitFacadeTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->dom->loadXML($directDebit->asXML());
-        $this->assertTrue($this->dom->schemaValidate($this->schema));
+        $this->assertTrue($this->dom->schemaValidate(__DIR__ . '/' . $schema . '.xsd'));
+    }
+
+    /**
+     * @return array
+     */
+    public function provideSchema()
+    {
+        return array(
+            array('pain.008.001.02'),
+            array('pain.008.002.02'),
+            array('pain.008.003.02')
+        );
     }
 }


### PR DESCRIPTION
This is only to verify that we do not break BC in any future release with all currently used `pain` formats and variants. This does not go down to the very first version of all variants but starts with those versions which are used in the method definitions.