### PR TITLE
Fixed amounts with decimals

### DIFF
--- a/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
+++ b/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
@@ -91,7 +91,7 @@ class BaseTransferInformation implements TransferInformationInterface
                 throw new InvalidArgumentException('Using floats for amount is only possible with bcmath enabled');
             }
             bcscale(2);
-            $amount = (integer)bcmul($amount, 100);
+            $amount = (integer)bcmul(number_format($amount, 2), '100');
         }
         $this->transferAmount = $amount;
         $this->iban = $iban;

--- a/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
+++ b/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
@@ -91,7 +91,7 @@ class BaseTransferInformation implements TransferInformationInterface
                 throw new InvalidArgumentException('Using floats for amount is only possible with bcmath enabled');
             }
             bcscale(2);
-            $amount = (integer)bcmul(number_format($amount, 2), '100');
+            $amount = (integer)bcmul(sprintf('%01.4F', $amount), '100');
         }
         $this->transferAmount = $amount;
         $this->iban = $iban;

--- a/tests/Unit/SumOutputTest.php
+++ b/tests/Unit/SumOutputTest.php
@@ -108,6 +108,35 @@ class SumOutputTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function floatSumIsCalculatedCorrectlyWithNonEnglishLocale()
+    {
+        $result = setlocale(LC_ALL, 'es_ES.UTF-8', 'es_ES@UTF-8', 'spanish');
+
+        if($result == false) {
+            $this->markTestSkipped('spanish locale is not available');
+        }
+
+        $this->createDirectDebitXpathObject('19.999');
+        $controlSum = $this->directDebitXpath->query('//sepa:GrpHdr/sepa:CtrlSum');
+        $this->assertEquals('19.99', $controlSum->item(0)->textContent, 'GroupHeader ControlSum should be 19.99');
+
+        $controlSum = $this->directDebitXpath->query('//sepa:PmtInf/sepa:CtrlSum');
+        $this->assertEquals(
+            '19.99',
+            $controlSum->item(0)->textContent,
+            'PaymentInformation ControlSum should be 19.99'
+        );
+        $controlSum = $this->directDebitXpath->query('//sepa:DrctDbtTxInf/sepa:InstdAmt');
+        $this->assertEquals(
+            '19.99',
+            $controlSum->item(0)->textContent,
+            'DirectDebitTransferInformation InstructedAmount should be 19.99'
+        );
+    }
+
+    /**
+     * @test
+     */
     public function floatsAreAcceptedIfBcMathExtensionIsAvailable()
     {
         if (!function_exists('bcscale')) {


### PR DESCRIPTION
bcmul() function expects [two strings](http://php.net/manual/en/function.bcmul.php#refsect1-function.bcmul-parameters) but BaseTransferInformation constructor uses a float and an integer. This usage converts float values with decimals into zeros depending on locale configuration, so each transfer is added with zero amount.

This behaviour is not clearly documented in PHP, but bcmul() an other BC Math functions casts parameters to strings returning inaccurate or directly wrong results without showing errors or throwing exceptions.

You can test with this code on Linux:

```
setlocale(LC_ALL, 'es_ES.UTF-8');
var_dump(bcmul(143.50, 100, 2));
setlocale(LC_ALL, 'C');
var_dump(bcmul(143.50, 100, 2));
```

Result:

```
string '0' (length=1)
string '14350.0' (length=7)
```

This can be solved using `number_format()` after converting the amount to float and 100 as a string, so floats with decimals can be safely used in transfers. Another way is change-and-restore the locale between calls, but is more complex and require locales to be available on the web server.

Note that `number_format()` [**also rounds**](http://php.net/manual/es/function.number-format.php#88424) the number, but is necessary. Just think in percentage discounts on amounts like 9.99. If I make a 75% discount I lose 1 cent (2.4975 is converted 2.49 instead of 2.50).

A workaround is convert amount to integer multiplying by 100 and use the result as amount, but use of strings or decimals, if allowed, must be safe.
