### PR TITLE
Update amendments with compliance to SDD Rulebook v9

### DIFF
--- a/doc/direct_credit.md
+++ b/doc/direct_credit.md
@@ -62,20 +62,3 @@ $domBuilder = DomBuilderFactory::createDomBuilder($sepaFile);
 
 $domBuilder->asXml();
 ```
-
-## Add an amendment to a transfer
-
-```php
-// Add a Single Transaction to the named payment
-$customerCredit->addTransfer('firstPayment', array(
-    'amount'                  => '500',
-    'creditorIban'            => 'FI1350001540000056',
-    'creditorBic'             => 'OKOYFIHH',
-    'creditorName'            => 'Their Company',
-    'remittanceInformation'   => 'Purpose of this credit transfer',
-    // Amendments start here
-    'originalMandateId'     => '1234567890',
-    'originalDebtorIban'    => 'AT711100015440033700',
-    'amendedDebtorAgent'    => true
-));
-```

--- a/doc/direct_debit.md
+++ b/doc/direct_debit.md
@@ -65,3 +65,20 @@ $directDebit->addTransfer('firstPayment', array(
 // Retrieve the resulting XML
 $directDebit->asXML();
 ```
+
+## Add an amendment to a transfer
+
+```php
+// Add a Single Transaction to the named payment
+$directDebit->addTransfer('firstPayment', array(
+    'amount'                  => '500',
+    'creditorIban'            => 'FI1350001540000056',
+    'creditorBic'             => 'OKOYFIHH',
+    'creditorName'            => 'Their Company',
+    'remittanceInformation'   => 'Purpose of this credit transfer',
+    // Amendments start here
+    'originalMandateId'     => '1234567890',
+    'originalDebtorIban'    => 'AT711100015440033700',
+    'amendedDebtorAccount' => true
+));
+```

--- a/lib/Digitick/Sepa/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -22,8 +22,6 @@
 
 namespace Digitick\Sepa\DomBuilder;
 
-use Digitick\Sepa\TransferFile\CustomerCreditTransferFile;
-use Digitick\Sepa\TransferFile\CustomerDirectDebitTransferFile;
 use Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation;
 use Digitick\Sepa\TransferInformation\TransferInformationInterface;
 use Digitick\Sepa\PaymentInformation;
@@ -41,7 +39,7 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
     /**
      * Build the root of the document
      *
-     * @param TransferFileInterface $transferFile
+     * @param  TransferFileInterface $transferFile
      * @return mixed
      */
     public function visitTransferFile(TransferFileInterface $transferFile)
@@ -53,7 +51,7 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
     /**
      * Crawl PaymentInformation containing the Transactions
      *
-     * @param PaymentInformation $paymentInformation
+     * @param  PaymentInformation $paymentInformation
      * @return mixed
      */
     public function visitPaymentInformation(PaymentInformation $paymentInformation)
@@ -128,7 +126,7 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
     /**
      * Crawl Transactions
      *
-     * @param TransferInformationInterface $transactionInformation
+     * @param  TransferInformationInterface $transactionInformation
      * @return mixed
      */
     public function visitTransferInformation(TransferInformationInterface $transactionInformation)
@@ -184,22 +182,16 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
 
             $amendmentInformationDetails = $this->createElement('AmdmntInfDtls');
 
-            if ($transactionInformation->hasAmendedDebtorAgent()) {
-                $originalDebtorAgent = $this->createElement('OrgnlDbtrAgt');
-                $financialInstitutionIdentification = $this->createElement('FinInstnId');
+            if ($transactionInformation->hasAmendedDebtorAccount() || $transactionInformation->getOriginalDebtorIban() !== null) {
+                $originalDebtorAccount = $this->createElement('OrgnlDbtrAcct');
+                $identification = $this->createElement('Id');
                 $other = $this->createElement('Othr');
-                // Same Mandate New Debtor Agent
+                // Same Mandate New Debtor Account
                 $id = $this->createElement('Id', 'SMNDA');
 
                 $other->appendChild($id);
-                $financialInstitutionIdentification->appendChild($other);
-                $originalDebtorAgent->appendChild($financialInstitutionIdentification);
-                $amendmentInformationDetails->appendChild($originalDebtorAgent);
-            }
-
-            if ($transactionInformation->getOriginalDebtorIban() !== null) {
-                $originalDebtorAccount = $this->createElement('OrgnlDbtrAcct');
-                $originalDebtorAccount->appendChild($this->getIbanElement($transactionInformation->getOriginalDebtorIban()));
+                $identification->appendChild($other);
+                $originalDebtorAccount->appendChild($identification);
                 $amendmentInformationDetails->appendChild($originalDebtorAccount);
             }
 
@@ -213,7 +205,6 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
 
         $this->currentPayment->appendChild($directDebitTransactionInformation);
     }
-
 
     /**
      * Add the specific OrgId element for the format 'pain.008.001.02'

--- a/lib/Digitick/Sepa/TransferFile/Facade/CustomerDirectDebitFacade.php
+++ b/lib/Digitick/Sepa/TransferFile/Facade/CustomerDirectDebitFacade.php
@@ -32,13 +32,13 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
     /**
      * @param $paymentName
      * @param array $paymentInformation
-     *     - id
-     *     - creditorName
-     *     - creditorAccountIBAN
-     *     - creditorAgentBIC
-     *     - seqType
-     *     - creditorId
-     *     - [dueDate] if not set: now + 5 days
+     *                                  - id
+     *                                  - creditorName
+     *                                  - creditorAccountIBAN
+     *                                  - creditorAgentBIC
+     *                                  - seqType
+     *                                  - creditorId
+     *                                  - [dueDate] if not set: now + 5 days
      *
      * @throws \Digitick\Sepa\Exception\InvalidArgumentException
      *
@@ -78,15 +78,15 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
     /**
      * @param $paymentName
      * @param array $transferInformation
-     *      - amount
-     *      - debtorIban
-     *      - debtorBic
-     *      - debtorName
-     *      - debtorMandate
-     *      - debtorMandateSignDate
-     *      - remittanceInformation
-     *      - [endToEndId]
-     *      - [amendments]
+     *                                   - amount
+     *                                   - debtorIban
+     *                                   - debtorBic
+     *                                   - debtorName
+     *                                   - debtorMandate
+     *                                   - debtorMandateSignDate
+     *                                   - remittanceInformation
+     *                                   - [endToEndId]
+     *                                   - [amendments]
      *
      * @throws \Digitick\Sepa\Exception\InvalidArgumentException
      *
@@ -126,8 +126,8 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
         if (isset($transferInformation['originalDebtorIban'])) {
             $transfer->setOriginalDebtorIban($transferInformation['originalDebtorIban']);
         }
-        if (isset($transferInformation['amendedDebtorAgent'])) {
-            $transfer->setAmendedDebtorAgent((bool)$transferInformation['amendedDebtorAgent']);
+        if (isset($transferInformation['amendedDebtorAccount'])) {
+            $transfer->setAmendedDebtorAccount((bool) $transferInformation['amendedDebtorAccount']);
         }
 
         $this->payments[$paymentName]->addTransfer($transfer);

--- a/lib/Digitick/Sepa/TransferInformation/CustomerDirectDebitTransferInformation.php
+++ b/lib/Digitick/Sepa/TransferInformation/CustomerDirectDebitTransferInformation.php
@@ -44,7 +44,7 @@ class CustomerDirectDebitTransferInformation extends BaseTransferInformation
     /**
      * @var bool
      */
-    protected $amendedDebtorAgent = false;
+    protected $amendedDebtorAccount = false;
 
     /**
      * @var string|null
@@ -78,7 +78,7 @@ class CustomerDirectDebitTransferInformation extends BaseTransferInformation
      */
     public function hasAmendments()
     {
-        return $this->amendedDebtorAgent
+        return $this->amendedDebtorAccount
             || $this->originalDebtorIban !== null
             || $this->originalMandateId !== null;
     }
@@ -86,17 +86,17 @@ class CustomerDirectDebitTransferInformation extends BaseTransferInformation
     /**
      * @return boolean
      */
-    public function hasAmendedDebtorAgent()
+    public function hasAmendedDebtorAccount()
     {
-        return $this->amendedDebtorAgent;
+        return $this->amendedDebtorAccount;
     }
 
     /**
      * @param bool $status
      */
-    public function setAmendedDebtorAgent($status)
+    public function setAmendedDebtorAccount($status)
     {
-        $this->amendedDebtorAgent = $status;
+        $this->amendedDebtorAccount = $status;
     }
 
     /**

--- a/tests/Unit/Digitick/Sepa/TransferInformation/CustomerDirectDebitTransferInformationTest.php
+++ b/tests/Unit/Digitick/Sepa/TransferInformation/CustomerDirectDebitTransferInformationTest.php
@@ -34,10 +34,10 @@ class CustomerDirectDebitTransferInformationTest extends \PHPUnit_Framework_Test
         );
         $this->assertFalse($transferInformation->hasAmendments());
 
-        $transferInformation->setAmendedDebtorAgent(true);
+        $transferInformation->setAmendedDebtorAccount(true);
         $this->assertTrue($transferInformation->hasAmendments());
 
-        $transferInformation->setAmendedDebtorAgent(false);
+        $transferInformation->setAmendedDebtorAccount(false);
         $transferInformation->setOriginalDebtorIban('DE89370400440532013000');
         $this->assertTrue($transferInformation->hasAmendments());
     }


### PR DESCRIPTION
> In the previous versions of the Guidelines, the acronym ‘SMNDA’ was used to indicate
Same Mandate with a New Debtor Agent. However, when the Creditor only receives the
IBAN it will not always be possible to derive if an account change took place in the same or
in another bank. To better accommodate this situation, the definition of the acronym
‘SMNDA’ has been updated to indicate Same Mandate with a New Debtor Account.

Source: http://www.europeanpaymentscouncil.eu/index.cfm/knowledge-bank/epc-documents/sepa-direct-debit-core-scheme-customer-to-bank-implementation-guidelines-version-90/epc130-08-sdd-core-c2b-ig-v90-approvedpdf/ (Section 1.5.4)


This PR updates the way amendments are added to the SEPA file to comply with the most recent direct debit rulebook (version 9). Readme and tests are updated accordingly.


Kind regards,
Jarno