### PR TITLE
Don't add RemittanceElement when there is no RemittanceInformation

### DIFF
--- a/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -172,8 +172,11 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         $CdtTrfTxInf->appendChild($creditorAccount);
 
         // remittance 2.98 2.99
-        $remittanceInformation = $this->getRemittenceElement($transactionInformation->getRemittanceInformation());
-        $CdtTrfTxInf->appendChild($remittanceInformation);
+        if (strlen($transactionInformation->getRemittanceInformation()) > 0)
+        {
+            $remittanceInformation = $this->getRemittenceElement($transactionInformation->getRemittanceInformation());
+            $CdtTrfTxInf->appendChild($remittanceInformation);
+        }
 
         $this->currentPayment->appendChild($CdtTrfTxInf);
     }

--- a/tests/CustomerCreditValidationTest.php
+++ b/tests/CustomerCreditValidationTest.php
@@ -387,6 +387,40 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test a transfer file with one payment without remittance information
+     *
+     * @param string $schema
+     *
+     * @dataProvider provideSchema
+     */
+    public function testSinglePaymentSingleTransWithoutRemitttanceInformation($schema)
+    {
+        $groupHeader = new GroupHeader('transferID', 'Me');
+        $sepaFile = new CustomerCreditTransferFile($groupHeader);
+
+        $transfer = new CustomerCreditTransferInformation('0.02', 'FI1350001540000056', 'Their Corp');
+        $transfer->setBic('OKOYFIHH');
+        $transfer->setEndToEndIdentification(uniqid());
+        $transfer->setInstructionId(uniqid());
+
+        $payment = new PaymentInformation('Payment Info ID', 'FR1420041010050500013M02606', 'PSSTFRPPMON', 'My Corp');
+        $payment->setValidPaymentMethods(array('TRANSFER'));
+        $payment->setPaymentMethod('TRANSFER');
+        $payment->setCategoryPurposeCode('SALA');
+        $payment->addTransfer($transfer);
+
+        $sepaFile->addPaymentInformation($payment);
+
+        $domBuilder = new CustomerCreditTransferDomBuilder($schema);
+        $sepaFile->accept($domBuilder);
+        $xml = $domBuilder->asXml();
+        $this->dom->loadXML($xml);
+
+        $validated = $this->dom->schemaValidate(__DIR__ . '/' . $schema . '.xsd');
+        $this->assertTrue($validated);
+    }
+
+    /**
      * @return array
      */
     public function provideSchema()


### PR DESCRIPTION
An empty <Ustrd/> element is invalid according PAIN specification.
I've added a test that fails without the fix provided.