### PR TITLE
Setters for organization id and identification scheme

### DIFF
--- a/lib/Digitick/Sepa/GroupHeader.php
+++ b/lib/Digitick/Sepa/GroupHeader.php
@@ -47,6 +47,12 @@ class GroupHeader
     protected $initiatingPartyId;
 
     /**
+     * Name of the identification scheme, in a coded form as published in an external list. 1-4 characters.
+     * @var string
+     */
+    public $initiatingPartyIdentificationScheme;
+
+    /**
      * The Issuer.
      *
      * @var string
@@ -129,6 +135,22 @@ class GroupHeader
     public function getInitiatingPartyId()
     {
         return $this->initiatingPartyId;
+    }
+
+    /**
+     * @param string $id
+     */
+    public function setInitiatingPartyIdentificationScheme($scheme)
+    {
+        $this->initiatingPartyIdentificationScheme = StringHelper::sanitizeString($scheme);
+    }
+
+    /**
+     * @return string
+     */
+    public function getInitiatingPartyIdentificationScheme()
+    {
+        return $this->initiatingPartyIdentificationScheme;
     }
 
     /**

--- a/lib/Digitick/Sepa/PaymentInformation.php
+++ b/lib/Digitick/Sepa/PaymentInformation.php
@@ -65,6 +65,18 @@ class PaymentInformation
     public $originName;
 
     /**
+     * Unique identification of an organisation, as assigned by an institution, using an identification scheme.
+     * @var string
+     */
+    public $originBankPartyIdentification;
+
+    /**
+     * Name of the identification scheme, in a coded form as published in an external list. 1-4 characters.
+     * @var string
+     */
+    public $originBankPartyIdentificationScheme;
+
+    /**
      * @var string Debtor's account IBAN.
      */
     public $originAccountIBAN;
@@ -290,6 +302,38 @@ class PaymentInformation
     public function getOriginName()
     {
         return $this->originName;
+    }
+
+    /**
+     * @param string $id
+     */
+    public function setOriginBankPartyIdentification($id)
+    {
+        $this->originBankPartyIdentification = StringHelper::sanitizeString($id);
+    }
+
+    /**
+     * @return string
+     */
+    public function getOriginBankPartyIdentification()
+    {
+        return $this->originBankPartyIdentification;
+    }
+
+    /**
+     * @param string $id
+     */
+    public function setOriginBankPartyIdentificationScheme($scheme)
+    {
+        $this->originBankPartyIdentificationScheme = StringHelper::sanitizeString($scheme);
+    }
+
+    /**
+     * @return string
+     */
+    public function getOriginBankPartyIdentificationScheme()
+    {
+        return $this->originBankPartyIdentificationScheme;
     }
 
     /**


### PR DESCRIPTION
Add get/setters for organization id and identification scheme in both PaymentInformation and GroupHeader.

Nordea Finland requires identification scheme code with organization id to work. Resulting XML passes Nordea XML validator.