### PR TITLE
Readme improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/doc/direct_debit.md
+++ b/doc/direct_debit.md
@@ -4,7 +4,8 @@ use Digitick\Sepa\TransferFile\Factory\TransferFileFacadeFactory;
 use Digitick\Sepa\PaymentInformation;
 
 //Set the initial information
-$directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me');
+// third parameter 'pain.008.003.02' is optional would default to 'pain.008.002.02' if not changed
+$directDebit = TransferFileFacadeFactory::createDirectDebit('SampleUniqueMsgId', 'SampleInitiatingPartyName', 'pain.008.003.02');
 
 // create a payment, it's possible to create multiple payments,
 // "firstPayment" is the identifier for the transactions

--- a/doc/direct_debit.md
+++ b/doc/direct_debit.md
@@ -8,13 +8,16 @@ $directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me');
 
 // create a payment, it's possible to create multiple payments,
 // "firstPayment" is the identifier for the transactions
+// This creates a one time debit. If needed change use ::S_FIRST, ::S_RECURRING or ::S_FINAL respectively
 $directDebit->addPaymentInfo('firstPayment', array(
     'id'                    => 'firstPayment',
+    'dueDate'               => new DateTime('now + 7 days'), // optional. Otherwise default period is used
     'creditorName'          => 'My Company',
     'creditorAccountIBAN'   => 'FI1350001540000056',
     'creditorAgentBIC'      => 'PSSTFRPPMON',
     'seqType'               => PaymentInformation::S_ONEOFF,
-    'creditorId'            => 'DE21WVM1234567890'
+    'creditorId'            => 'DE21WVM1234567890',
+    'localInstrumentCode'   => 'CORE' // default. optional.
 ));
 // Add a Single Transaction to the named payment
 $directDebit->addTransfer('firstPayment', array(
@@ -22,9 +25,10 @@ $directDebit->addTransfer('firstPayment', array(
     'debtorIban'            => 'FI1350001540000056',
     'debtorBic'             => 'OKOYFIHH',
     'debtorName'            => 'Their Company',
-    'debtorMandate'         =>  'AB12345',
+    'debtorMandate'         => 'AB12345',
     'debtorMandateSignDate' => '13.10.2012',
-    'remittanceInformation' => 'Purpose of this direct debit'
+    'remittanceInformation' => 'Purpose of this direct debit',
+    'endToEndId'            => 'Invoice-No X' // optional, if you want to provide additional structured info
 ));
 // Retrieve the resulting XML
 $directDebit->asXML();
@@ -46,11 +50,13 @@ $directDebit = TransferFileFacadeFactory::createDirectDebitWithGroupHeader($head
 // "firstPayment" is the identifier for the transactions
 $directDebit->addPaymentInfo('firstPayment', array(
     'id'                    => 'firstPayment',
+    'dueDate'               => new DateTime('now + 7 days'), // optional. Otherwise default period is used
     'creditorName'          => 'My Company',
     'creditorAccountIBAN'   => 'FI1350001540000056',
     'creditorAgentBIC'      => 'PSSTFRPPMON',
     'seqType'               => PaymentInformation::S_ONEOFF,
-    'creditorId'            => 'DE21WVM1234567890'
+    'creditorId'            => 'DE21WVM1234567890',
+    'localInstrumentCode'   => 'CORE' // default. optional.
 ));
 // Add a Single Transaction to the named payment
 $directDebit->addTransfer('firstPayment', array(
@@ -60,7 +66,8 @@ $directDebit->addTransfer('firstPayment', array(
     'debtorName'            => 'Their Company',
     'debtorMandate'         =>  'AB12345',
     'debtorMandateSignDate' => '13.10.2012',
-    'remittanceInformation' => 'Purpose of this direct debit'
+    'remittanceInformation' => 'Purpose of this direct debit',
+    'endToEndId'            => 'Invoice-No X' // optional, if you want to provide additional structured info
 ));
 // Retrieve the resulting XML
 $directDebit->asXML();
@@ -76,9 +83,10 @@ $directDebit->addTransfer('firstPayment', array(
     'creditorBic'             => 'OKOYFIHH',
     'creditorName'            => 'Their Company',
     'remittanceInformation'   => 'Purpose of this credit transfer',
+    'endToEndId'              => 'Invoice-No X' // optional, if you want to provide additional structured info
     // Amendments start here
-    'originalMandateId'     => '1234567890',
-    'originalDebtorIban'    => 'AT711100015440033700',
-    'amendedDebtorAccount' => true
+    'originalMandateId'       => '1234567890',
+    'originalDebtorIban'      => 'AT711100015440033700',
+    'amendedDebtorAccount'    => true
 ));
 ```


### PR DESCRIPTION
Since I just implemented the library yesterday and had a bit of a slow start, I am submitting some improvements to the readme:

- Supplying endToEndId and making comment that it is optional
- Supplying dueDate with now +7 days, since this is usually the default by consumer law (at least in DE)
- exposing CORE default
- Gave initiating variables a clearer name 
- Using pain.008.003.02 in example. With our bank this was the preferred schema. I was not quite clear, why you still supply the old as default? 

I hope these improvements make sense, as I think that the use-case of making a direct debit IRL more often includes these params than it would omit them. Therefore it makes sense to include them in the "getting started" Readme.
