### PR TITLE
Add instruction priority to payment information

### DIFF
--- a/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -81,6 +81,10 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         );
 
         $paymentTypeInformation = $this->createElement('PmtTpInf');
+        if($paymentInformation->getInstructionPriority()) {
+            $instructionPriority = $this->createElement('InstrPrty', $paymentInformation->getInstructionPriority());
+            $paymentTypeInformation->appendChild($instructionPriority);
+        }
         $serviceLevel = $this->createElement('SvcLvl');
         $serviceLevel->appendChild($this->createElement('Cd', 'SEPA'));
         $paymentTypeInformation->appendChild($serviceLevel);

--- a/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -81,7 +81,7 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         );
 
         $paymentTypeInformation = $this->createElement('PmtTpInf');
-        if($paymentInformation->getInstructionPriority()) {
+        if ($paymentInformation->getInstructionPriority()) {
             $instructionPriority = $this->createElement('InstrPrty', $paymentInformation->getInstructionPriority());
             $paymentTypeInformation->appendChild($instructionPriority);
         }

--- a/lib/Digitick/Sepa/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -73,6 +73,10 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
         );
 
         $paymentTypeInformation = $this->createElement('PmtTpInf');
+        if($paymentInformation->getInstructionPriority() && $this->painFormat === 'pain.008.001.02') {
+            $instructionPriority = $this->createElement('InstrPrty', $paymentInformation->getInstructionPriority());
+            $paymentTypeInformation->appendChild($instructionPriority);
+        }
         $serviceLevel = $this->createElement('SvcLvl');
         $serviceLevel->appendChild($this->createElement('Cd', 'SEPA'));
         $paymentTypeInformation->appendChild($serviceLevel);

--- a/lib/Digitick/Sepa/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -73,7 +73,7 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
         );
 
         $paymentTypeInformation = $this->createElement('PmtTpInf');
-        if($paymentInformation->getInstructionPriority() && $this->painFormat === 'pain.008.001.02') {
+        if ($paymentInformation->getInstructionPriority() && $this->painFormat === 'pain.008.001.02') {
             $instructionPriority = $this->createElement('InstrPrty', $paymentInformation->getInstructionPriority());
             $paymentTypeInformation->appendChild($instructionPriority);
         }

--- a/lib/Digitick/Sepa/PaymentInformation.php
+++ b/lib/Digitick/Sepa/PaymentInformation.php
@@ -109,6 +109,11 @@ class PaymentInformation
     protected $dueDate;
 
     /**
+     * @var string Instruction priority.
+     */
+    protected $instructionPriority;
+
+    /**
      * @var integer
      */
     protected $controlSumCents = 0;
@@ -275,6 +280,26 @@ class PaymentInformation
     public function getDueDate()
     {
         return $this->dueDate->format($this->dateFormat);
+    }
+
+    /**
+     * @param string $instructionPriority
+     */
+    public function setInstructionPriority($instructionPriority)
+    {
+        $instructionPriority = strtoupper($instructionPriority);
+        if (!in_array($instructionPriority, array('NORM', 'HIGH'))) {
+            throw new InvalidArgumentException("Invalid Instruction Priority: $instructionPriority");
+        }
+        $this->instructionPriority = $instructionPriority;
+    }
+
+    /**
+     * @return string
+     */
+    public function getInstructionPriority()
+    {
+        return $this->instructionPriority;
     }
 
     /**

--- a/tests/CustomerCreditValidationTest.php
+++ b/tests/CustomerCreditValidationTest.php
@@ -201,6 +201,7 @@ class CustomerCreditValidationTest extends \PHPUnit_Framework_TestCase
         $sepaFile = new CustomerCreditTransferFile($groupHeader);
         $payment = new PaymentInformation('Payment Info ID', 'FR1420041010050500013M02606', 'PSSTFRPPMON', 'My Corp');
         $payment->setDueDate(new \DateTime('20.11.2012'));
+        $payment->setInstructionPriority('NORM');
 
         $transfer = new CustomerCreditTransferInformation('0.02', 'FI1350001540000056', 'Their Corp');
         $transfer->setBic('OKOYFIHH');

--- a/tests/CustomerDirectDebitValidationTest.php
+++ b/tests/CustomerDirectDebitValidationTest.php
@@ -81,6 +81,7 @@ class CustomerDirectDebitValidationTest extends \PHPUnit_Framework_TestCase
         $payment = new PaymentInformation('Payment Info ID', 'FR1420041010050500013M02606', 'PSSTFRPPMON', 'My Corp');
         $payment->setSequenceType(PaymentInformation::S_ONEOFF);
         $payment->setDueDate(new \DateTime('22.08.2013'));
+        $payment->setInstructionPriority('NORM');
         $payment->setCreditorId('DE21WVM1234567890');
         $payment->addTransfer($transfer);
 


### PR DESCRIPTION
Hi and thanks for this library :cat: I would like to set `instruction priority` in `payment type information` as defined eg. [here](https://github.com/php-sepa-xml/php-sepa-xml/blob/8f9814bc7c97eda669e93848df3dcdb28ca7debb/tests/pain.001.001.03.xsd#L669). Could you please have a look on this pull request? Thanks for your time.