### PR TITLE
Settings to use it for Jyske Bank

### DIFF
--- a/lib/Digitick/Sepa/DomBuilder/BaseDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/BaseDomBuilder.php
@@ -119,13 +119,18 @@ abstract class BaseDomBuilder implements DomBuilderInterface
         );
         $groupHeaderTag->appendChild($creationDateTime);
         $groupHeaderTag->appendChild($this->createElement('NbOfTxs', $groupHeader->getNumberOfTransactions()));
-        $groupHeaderTag->appendChild(
-            $this->createElement('CtrlSum', $this->intToCurrency($groupHeader->getControlSumCents()))
-        );
+
+        if ($groupHeader->hasHiddenControlSum() === false) {
+            $groupHeaderTag->appendChild(
+                $this->createElement('CtrlSum', $this->intToCurrency($groupHeader->getControlSumCents()))
+            );
+        }
 
         $initiatingParty = $this->createElement('InitgPty');
-        $initiatingPartyName = $this->createElement('Nm', $groupHeader->getInitiatingPartyName());
-        $initiatingParty->appendChild($initiatingPartyName);
+        if ($groupHeader->hasHiddenInitiatingPartyName() === false) {
+            $initiatingPartyName = $this->createElement('Nm', $groupHeader->getInitiatingPartyName());
+            $initiatingParty->appendChild($initiatingPartyName);
+        }
         if ($groupHeader->getInitiatingPartyId() !== null) {
             $id = $this->createElement('Id', $groupHeader->getInitiatingPartyId());
             $initiatingParty->appendChild($id);

--- a/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -72,28 +72,31 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
             $this->currentPayment->appendChild($this->createElement('BtchBookg', $paymentInformation->getBatchBooking() ? 'true' : 'false'));
         }
 
-        $this->currentPayment->appendChild(
-            $this->createElement('NbOfTxs', $paymentInformation->getNumberOfTransactions())
-        );
+        if ($paymentInformation->hasHiddenGeneralSettings() === false) {
+            $this->currentPayment->appendChild(
+                $this->createElement('NbOfTxs', $paymentInformation->getNumberOfTransactions())
+            );
 
-        $this->currentPayment->appendChild(
-            $this->createElement('CtrlSum', $this->intToCurrency($paymentInformation->getControlSumCents()))
-        );
+            $this->currentPayment->appendChild(
+                $this->createElement('CtrlSum', $this->intToCurrency($paymentInformation->getControlSumCents()))
+            );
 
-        $paymentTypeInformation = $this->createElement('PmtTpInf');
-        if ($paymentInformation->getInstructionPriority()) {
-            $instructionPriority = $this->createElement('InstrPrty', $paymentInformation->getInstructionPriority());
-            $paymentTypeInformation->appendChild($instructionPriority);
+            $paymentTypeInformation = $this->createElement('PmtTpInf');
+            if ($paymentInformation->getInstructionPriority()) {
+                $instructionPriority = $this->createElement('InstrPrty', $paymentInformation->getInstructionPriority());
+                $paymentTypeInformation->appendChild($instructionPriority);
+            }
+            $serviceLevel = $this->createElement('SvcLvl');
+            $serviceLevel->appendChild($this->createElement('Cd', $paymentInformation->getServiceLevel()));
+            $paymentTypeInformation->appendChild($serviceLevel);
+
+            if ($paymentInformation->getCategoryPurposeCode()) {
+                $categoryPurpose = $this->createElement('CtgyPurp');
+                $categoryPurpose->appendChild($this->createElement('Cd', $paymentInformation->getCategoryPurposeCode()));
+                $paymentTypeInformation->appendChild($categoryPurpose);
+            }
+            $this->currentPayment->appendChild($paymentTypeInformation);
         }
-        $serviceLevel = $this->createElement('SvcLvl');
-        $serviceLevel->appendChild($this->createElement('Cd', $paymentInformation->getServiceLevel()));
-        $paymentTypeInformation->appendChild($serviceLevel);
-        if ($paymentInformation->getCategoryPurposeCode()) {
-            $categoryPurpose = $this->createElement('CtgyPurp');
-            $categoryPurpose->appendChild($this->createElement('Cd', $paymentInformation->getCategoryPurposeCode()));
-            $paymentTypeInformation->appendChild($categoryPurpose);
-        }
-        $this->currentPayment->appendChild($paymentTypeInformation);
 
         if ($paymentInformation->getLocalInstrumentCode()) {
             $localInstrument = $this->createElement('LclInstr');
@@ -104,6 +107,11 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         $this->currentPayment->appendChild($this->createElement('ReqdExctnDt', $paymentInformation->getDueDate()));
         $debtor = $this->createElement('Dbtr');
         $debtor->appendChild($this->createElement('Nm', $paymentInformation->getOriginName()));
+        if ($paymentInformation->getCountry()) {
+            $postalAddress = $this->createElement('PstlAdr');
+            $postalAddress->appendChild($this->createElement('Ctry', $paymentInformation->getCountry()));
+            $debtor->appendChild($postalAddress);
+        }
         $this->currentPayment->appendChild($debtor);
 
         if ($paymentInformation->getOriginBankPartyIdentification() !== null && $this->painFormat === 'pain.001.001.03') {
@@ -116,7 +124,16 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
 
         $debtorAccount = $this->createElement('DbtrAcct');
         $id = $this->createElement('Id');
-        $id->appendChild($this->createElement('IBAN', $paymentInformation->getOriginAccountIBAN()));
+        if ($paymentInformation->hasHiddenOriginAccountIBAN() === false) {
+            $id->appendChild($this->createElement('IBAN', $paymentInformation->getOriginAccountIBAN()));
+        } else {
+            $othr = $this->createElement('Othr');
+            $schemeName = $this->createElement('SchmeNm');
+            $schemeName->appendChild($this->createElement('Cd', $paymentInformation->getOriginBankPartyIdentificationScheme()));
+            $othr->appendChild($this->createElement('Id', $paymentInformation->getOriginAccountIBAN()));
+            $othr->appendChild($schemeName);
+            $id->appendChild($othr);
+        }
         $debtorAccount->appendChild($id);
         if ($paymentInformation->getOriginAccountCurrency()) {
             $debtorAccount->appendChild($this->createElement('Ccy', $paymentInformation->getOriginAccountCurrency()));
@@ -124,11 +141,21 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         $this->currentPayment->appendChild($debtorAccount);
 
         $debtorAgent = $this->createElement('DbtrAgt');
-        $financialInstitutionId = $this->getFinancialInstitutionElement($paymentInformation->getOriginAgentBIC());
+        if ($paymentInformation->getOriginAgentBIC() === null && $paymentInformation->getCountry()) {
+            $financialInstitutionId = $this->createElement('FinInstnId');
+            $postalAddress = $this->createElement('PstlAdr');
+            $postalAddress->appendChild($this->createElement('Ctry', $paymentInformation->getCountry()));
+            $financialInstitutionId->appendChild($postalAddress);
+        } else {
+            $financialInstitutionId = $this->getFinancialInstitutionElement($paymentInformation->getOriginAgentBIC());
+        }
         $debtorAgent->appendChild($financialInstitutionId);
         $this->currentPayment->appendChild($debtorAgent);
 
-        $this->currentPayment->appendChild($this->createElement('ChrgBr', 'SLEV'));
+        if ($paymentInformation->hasHiddenGeneralSettings() === false) {
+            $this->currentPayment->appendChild($this->createElement('ChrgBr', 'SLEV'));
+        }
+
         $this->currentTransfer->appendChild($this->currentPayment);
     }
 
@@ -151,6 +178,31 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         $PmtId->appendChild($this->createElement('EndToEndId', $transactionInformation->getEndToEndIdentification()));
         $CdtTrfTxInf->appendChild($PmtId);
 
+        // Add payment settings
+        if ($transactionInformation->getServiceLevel() && $transactionInformation->getLocalInstrumentCode()) {
+            $paymentTypeInformation = $this->createElement('PmtTpInf');
+            $serviceLevel = $this->createElement('SvcLvl');
+            $serviceLevel->appendChild($this->createElement('Cd', $transactionInformation->getServiceLevel()));
+            $paymentTypeInformation->appendChild($serviceLevel);
+
+            if ($transactionInformation->getLocalInstrumentCode()) {
+                $localInstrumentCode = $this->createElement('LclInstrm');
+                $localInstrumentCode->appendChild(
+                    $this->createElement('Cd', $transactionInformation->getLocalInstrumentCode())
+                );
+                $paymentTypeInformation->appendChild($localInstrumentCode);
+            }
+
+            if ($transactionInformation->getCategoryPurposeCode()) {
+                $categoryPurpose = $this->createElement('CtgyPurp');
+                $categoryPurpose->appendChild(
+                    $this->createElement('Cd', $transactionInformation->getCategoryPurposeCode())
+                );
+                $paymentTypeInformation->appendChild($categoryPurpose);
+            }
+            $CdtTrfTxInf->appendChild($paymentTypeInformation);
+        }
+
         // Amount 2.42
         $amount = $this->createElement('Amt');
         $instructedAmount = $this->createElement(
@@ -160,6 +212,11 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         $instructedAmount->setAttribute('Ccy', $transactionInformation->getCurrency());
         $amount->appendChild($instructedAmount);
         $CdtTrfTxInf->appendChild($amount);
+
+        // Add charge bearer
+        if ($transactionInformation->getChargeBearer()) {
+            $CdtTrfTxInf->appendChild($this->createElement('ChrgBr', $transactionInformation->getChargeBearer()));
+        }
 
         //Creditor Agent 2.77
         if ($transactionInformation->getBic()) {
@@ -271,7 +328,7 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
 
         $postalAddress = $this->createElement('PstlAdr');
 
-        // Gemerate country address node.
+        // Generate country address node.
         if ((bool)$transactionInformation->getCountry()) {
             $postalAddress->appendChild($this->createElement('Ctry', $transactionInformation->getCountry()));
         }

--- a/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -86,7 +86,7 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
             $paymentTypeInformation->appendChild($instructionPriority);
         }
         $serviceLevel = $this->createElement('SvcLvl');
-        $serviceLevel->appendChild($this->createElement('Cd', 'SEPA'));
+        $serviceLevel->appendChild($this->createElement('Cd', $paymentInformation->getServiceLevel()));
         $paymentTypeInformation->appendChild($serviceLevel);
         if ($paymentInformation->getCategoryPurposeCode()) {
             $categoryPurpose = $this->createElement('CtgyPurp');

--- a/lib/Digitick/Sepa/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/lib/Digitick/Sepa/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -247,7 +247,9 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
     {
         parent::visitGroupHeader($groupHeader);
 
-        if ($groupHeader->getInitiatingPartyId() !== null && in_array($this->painFormat , array('pain.008.001.02','pain.008.003.02'))) {
+        if ($groupHeader->getInitiatingPartyId() !== null
+            && (in_array($this->painFormat, ['pain.008.001.02','pain.008.003.02']) || $groupHeader->hasForcedInitiatingPartyId())
+        ) {
             $newId = $this->createElement('Id');
             $orgId = $this->createElement('OrgId');
             $othr  = $this->createElement('Othr');

--- a/lib/Digitick/Sepa/GroupHeader.php
+++ b/lib/Digitick/Sepa/GroupHeader.php
@@ -53,6 +53,18 @@ class GroupHeader
     public $initiatingPartyIdentificationScheme;
 
     /**
+     * Will use the ID instead of name in the header
+     *
+     * @var bool
+     */
+    protected $forceInitiatingPartyId = false;
+
+    /**
+     * @var bool
+     */
+    protected $hideControlSum = false;
+
+    /**
      * The Issuer.
      *
      * @var string
@@ -73,6 +85,11 @@ class GroupHeader
      * @var string
      */
     protected $initiatingPartyName;
+
+    /**
+     * @var bool
+     */
+    protected $hideInitiatingPartyName = false;
 
     /**
      * @var \DateTime
@@ -255,5 +272,44 @@ class GroupHeader
     public function getCreationDateTimeFormat()
     {
         return $this->creationDateTimeFormat;
+    }
+
+    public function forceInitiatingPartyId()
+    {
+        $this->forceInitiatingPartyId = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasForcedInitiatingPartyId()
+    {
+        return $this->forceInitiatingPartyId;
+    }
+
+    public function hideControlSum()
+    {
+        $this->hideControlSum = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasHiddenControlSum()
+    {
+        return $this->hideControlSum;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasHiddenInitiatingPartyName()
+    {
+        return $this->hideInitiatingPartyName;
+    }
+
+    public function hideInitiatingPartyName()
+    {
+        $this->hideInitiatingPartyName = true;
     }
 }

--- a/lib/Digitick/Sepa/PaymentInformation.php
+++ b/lib/Digitick/Sepa/PaymentInformation.php
@@ -126,7 +126,7 @@ class PaymentInformation
     /**
      * @var array<TransferInformationInterface>
      */
-    protected $transfers = array();
+    protected $transfers = [];
 
     /**
      * Valid Payment Methods set by the TransferFile
@@ -170,6 +170,33 @@ class PaymentInformation
     protected $serviceLevel = 'SEPA';
 
     /**
+     * IBAN or BBAN
+     *
+     * @var string
+     */
+    protected $schemaName = 'IBAN';
+
+    /**
+     * @var bool
+     */
+    protected $hideControlSum = false;
+
+    /**
+     * @var bool
+     */
+    protected $hideOriginAccountIBAN = false;
+
+    /**
+     * @var bool
+     */
+    protected $hideGeneralSettings = false;
+
+    /**
+     * @var string
+     */
+    protected $country;
+
+    /**
      * @param string $id
      * @param string $originAccountIBAN This is your IBAN
      * @param string $originAgentBIC This is your BIC
@@ -185,7 +212,6 @@ class PaymentInformation
         $this->originAccountCurrency = $originAccountCurrency;
         $this->dueDate = new \DateTime();
     }
-
 
     /**
      * @param TransferInformationInterface $transfer
@@ -243,7 +269,7 @@ class PaymentInformation
     public function setLocalInstrumentCode($localInstrumentCode)
     {
         $localInstrumentCode = strtoupper($localInstrumentCode);
-        if (!in_array($localInstrumentCode, array('B2B', 'CORE', 'COR1', 'IN', 'ONCL'))) {
+        if (!in_array($localInstrumentCode, ['B2B', 'CORE', 'COR1', 'IN', 'ONCL'])) {
             throw new InvalidArgumentException("Invalid Local Instrument Code: $localInstrumentCode");
         }
         $this->localInstrumentCode = $localInstrumentCode;
@@ -295,7 +321,7 @@ class PaymentInformation
     public function setInstructionPriority($instructionPriority)
     {
         $instructionPriority = strtoupper($instructionPriority);
-        if (!in_array($instructionPriority, array('NORM', 'HIGH'))) {
+        if (!in_array($instructionPriority, ['NORM', 'HIGH'])) {
             throw new InvalidArgumentException("Invalid Instruction Priority: $instructionPriority");
         }
         $this->instructionPriority = $instructionPriority;
@@ -526,10 +552,17 @@ class PaymentInformation
     }
 
     /**
-     * @param string $serviceLevel
+     * @param $serviceLevel
+     *
+     * @throws InvalidArgumentException
      */
     public function setServiceLevel($serviceLevel)
     {
+        $serviceLevel = strtoupper($serviceLevel);
+        if (!in_array($serviceLevel, ['SEPA', 'NURG'])) {
+            throw new InvalidArgumentException("Invalid Service Level: $serviceLevel");
+        }
+
         $this->serviceLevel = $serviceLevel;
     }
 
@@ -539,5 +572,41 @@ class PaymentInformation
     public function getServiceLevel()
     {
         return $this->serviceLevel;
+    }
+
+    public function hideOriginAccountIBAN()
+    {
+        $this->hideOriginAccountIBAN = true;
+    }
+
+    public function hasHiddenOriginAccountIBAN()
+    {
+        return $this->hideOriginAccountIBAN;
+    }
+
+    public function hideGeneralSettings()
+    {
+        $this->hideGeneralSettings = true;
+    }
+
+    public function hasHiddenGeneralSettings()
+    {
+        return $this->hideGeneralSettings;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+    /**
+     * @param string $country
+     */
+    public function setCountry(string $country)
+    {
+        $this->country = $country;
     }
 }

--- a/lib/Digitick/Sepa/PaymentInformation.php
+++ b/lib/Digitick/Sepa/PaymentInformation.php
@@ -163,6 +163,13 @@ class PaymentInformation
     protected $dateFormat = 'Y-m-d';
 
     /**
+     * Servicelevel used in payment, default is SEPA
+     *
+     * @var string
+     */
+    protected $serviceLevel = 'SEPA';
+
+    /**
      * @param string $id
      * @param string $originAccountIBAN This is your IBAN
      * @param string $originAgentBIC This is your BIC
@@ -236,7 +243,7 @@ class PaymentInformation
     public function setLocalInstrumentCode($localInstrumentCode)
     {
         $localInstrumentCode = strtoupper($localInstrumentCode);
-        if (!in_array($localInstrumentCode, array('B2B', 'CORE', 'COR1'))) {
+        if (!in_array($localInstrumentCode, array('B2B', 'CORE', 'COR1', 'IN', 'ONCL'))) {
             throw new InvalidArgumentException("Invalid Local Instrument Code: $localInstrumentCode");
         }
         $this->localInstrumentCode = $localInstrumentCode;
@@ -516,5 +523,21 @@ class PaymentInformation
     public function setDueDateFormat($format)
     {
         $this->dateFormat = $format;
+    }
+
+    /**
+     * @param string $serviceLevel
+     */
+    public function setServiceLevel($serviceLevel)
+    {
+        $this->serviceLevel = $serviceLevel;
+    }
+
+    /**
+     * @return string
+     */
+    public function getServiceLevel()
+    {
+        return $this->serviceLevel;
     }
 }

--- a/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
+++ b/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
@@ -101,6 +101,26 @@ class BaseTransferInformation implements TransferInformationInterface
     protected $postalAddress;
 
     /**
+     * @var string
+     */
+    protected $localInstrumentCode;
+
+    /**
+     * @var string
+     */
+    protected $serviceLevel;
+
+    /**
+     * @var string
+     */
+    protected $chargeBearer;
+
+    /**
+     * @var string
+     */
+    protected $categoryPurposeCode;
+
+    /**
      * @param string $amount
      * @param string $iban
      * @param string $name
@@ -289,5 +309,73 @@ class BaseTransferInformation implements TransferInformationInterface
     public function setPostalAddress($postalAddress)
     {
         $this->postalAddress = $postalAddress;
+    }
+    /**
+     * @param string $localInstrumentCode
+     * @throws InvalidArgumentException
+     */
+    public function setLocalInstrumentCode($localInstrumentCode)
+    {
+        $localInstrumentCode = strtoupper($localInstrumentCode);
+        if (!in_array($localInstrumentCode, ['B2B', 'CORE', 'COR1', 'IN', 'ONCL'])) {
+            throw new InvalidArgumentException("Invalid Local Instrument Code: $localInstrumentCode");
+        }
+        $this->localInstrumentCode = $localInstrumentCode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLocalInstrumentCode()
+    {
+        return $this->localInstrumentCode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getServiceLevel()
+    {
+        return $this->serviceLevel;
+    }
+
+    /**
+     * @param string $serviceLevel
+     */
+    public function setServiceLevel(string $serviceLevel): void
+    {
+        $this->serviceLevel = $serviceLevel;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getChargeBearer()
+    {
+        return $this->chargeBearer;
+    }
+
+    /**
+     * @param string $chargeBearer
+     */
+    public function setChargeBearer(string $chargeBearer): void
+    {
+        $this->chargeBearer = $chargeBearer;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCategoryPurposeCode()
+    {
+        return $this->categoryPurposeCode;
+    }
+
+    /**
+     * @param string $categoryPurposeCode
+     */
+    public function setCategoryPurposeCode(string $categoryPurposeCode): void
+    {
+        $this->categoryPurposeCode = $categoryPurposeCode;
     }
 }


### PR DESCRIPTION
If we want to use this package for Jyske Bank with DKK payments as well as Euro payments we need to make some adjustments. The ServiceLevel needs to be able to change to NURG instead of SEPA, and we need different options for the LocalInstrument, IN and ONCL.