### PR TITLE
Init $paymentInformations value

### DIFF
--- a/lib/Digitick/Sepa/TransferFile/BaseTransferFile.php
+++ b/lib/Digitick/Sepa/TransferFile/BaseTransferFile.php
@@ -37,7 +37,7 @@ abstract class BaseTransferFile implements TransferFileInterface
     /**
      * @var array<PaymentInformation>
      */
-    protected $paymentInformations;
+    protected $paymentInformations = [];
 
     /**
      * @param GroupHeader $groupHeader


### PR DESCRIPTION
The validate function return an error because count($this->paymentInformations) can be done if there is no paymentInformations.