### PR TITLE
To produce the HCT variant of pain.001.001.03 format

### DIFF
--- a/lib/Digitick/Sepa/GroupHeader.php
+++ b/lib/Digitick/Sepa/GroupHeader.php
@@ -87,12 +87,12 @@ class GroupHeader
     /**
      * @param string $messageIdentification Maximum length: 35. Reference Number of the bulk.
      *                                      Part of the duplication check (unique daily reference).
-     *                                      The first 8 or 11 characters of <Msgld> must match the BIC of the
-     *                                      Instructing Agent. The rest of the field can be freely defined.
+     *                                      The HCT domestic default <Msgld> contains the prefix 'HUF-'
+     *                                      followed by the date+time using the format 'ymdHis'.
      * @param string $initiatingPartyName
      * @param boolean $isTest
      */
-    public function __construct($messageIdentification, $initiatingPartyName, $isTest = false)
+    public function __construct($messageIdentification = 'HUF-'.date('ymdHis'), $initiatingPartyName, $isTest = false)
     {
         $this->messageIdentification = $messageIdentification;
         $this->isTest = $isTest;

--- a/lib/Digitick/Sepa/PaymentInformation.php
+++ b/lib/Digitick/Sepa/PaymentInformation.php
@@ -165,17 +165,17 @@ class PaymentInformation
     /**
      * @param string $id
      * @param string $originAccountIBAN This is your IBAN
-     * @param string $originAgentBIC This is your BIC
      * @param string $originName This is your Name
-     * @param string $originAccountCurrency
+     * @param string $originAccountCurrency The HCT defaults to HUF
+     * @param string $originAgentBIC Not required for HCT
      */
-    public function __construct($id, $originAccountIBAN, $originAgentBIC, $originName, $originAccountCurrency = 'EUR')
+    public function __construct($id, $originAccountIBAN, $originName, $originAccountCurrency = 'HUF', $originAgentBIC = null)
     {
         $this->id = $id;
         $this->originAccountIBAN = $originAccountIBAN;
-        $this->originAgentBIC = $originAgentBIC;
         $this->originName = StringHelper::sanitizeString($originName);
         $this->originAccountCurrency = $originAccountCurrency;
+        $this->originAgentBIC = $originAgentBIC;
         $this->dueDate = new \DateTime();
     }
 


### PR DESCRIPTION
This PR is attaching to the discussion started in #95 

To produce the HCT variant of pain.001.001.03 format, that validates against the XSD available at [giro.hu HCT documents](https://www.giro.hu/documents/hct-documents)

I also commented into the code, to mark changes, i had to make, to switch off generating parts, that blocked validation.

A breaking change that would need to be worked around:

- Line 168/172  lib/Digitick/Sepa/PaymentInformation.php - The $originAgentBIC is not a required+optional part of the HCT, thus a simple declaration change to `$originAgentBIC = null, ` would still require to provide the variable on constructing.

- The change in lib/Digitick/Sepa/GroupHeader.php is not a required one, but in case there would be a separate fork, the defaults could be aligned to the usual content.
