### PR TITLE
Stop throwing Exception if bcmath is not enabled

### DIFF
--- a/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
+++ b/lib/Digitick/Sepa/TransferInformation/BaseTransferInformation.php
@@ -104,18 +104,17 @@ class BaseTransferInformation implements TransferInformationInterface
      * @param string $amount
      * @param string $iban
      * @param string $name
-     *
-     * @throws InvalidArgumentException
      */
     public function __construct($amount, $iban, $name)
     {
         $amount += 0;
         if (is_float($amount)) {
-            if (!function_exists('bcscale')) {
-                throw new InvalidArgumentException('Using floats for amount is only possible with bcmath enabled');
+            if (function_exists('bcscale')) {
+                bcscale(2);
+                $amount = (integer) bcmul(sprintf('%01.4F', $amount), '100');
+            } else {
+                $amount = (integer) ($amount * 100);
             }
-            bcscale(2);
-            $amount = (integer)bcmul(sprintf('%01.4F', $amount), '100');
         }
         $this->transferAmount = $amount;
         $this->iban = $iban;


### PR DESCRIPTION
@monofone This allows BaseTransferInformation to work with float even if bcmath is not enabled. Most of the time, the `*` operator is enough for float. 