### PR TITLE
add important breaking change info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
 - Add throws tag [\#100](https://github.com/php-sepa-xml/php-sepa-xml/pull/100) ([VincentLanglet](https://github.com/VincentLanglet))
 - Increase php versions to run tests for [\#97](https://github.com/php-sepa-xml/php-sepa-xml/pull/97) ([monofone](https://github.com/monofone))
 
+**Important changes:**
+
+- The direct debit transfer amount has been changed from string to int. You must add the amount as integer cent values, otherwise the SEPA export may contain wrong amounts.
+
 ## [1.6.2](https://github.com/php-sepa-xml/php-sepa-xml/tree/1.6.2) (2020-02-13)
 
 [Full Changelog](https://github.com/php-sepa-xml/php-sepa-xml/compare/1.6.1...1.6.2)


### PR DESCRIPTION
Hi folks, thanks for your work on this library.

I upgraded my project from 1.6.2 to 2.0.1 and did miss the fact, that the amount definition changed.
That caused my project to create an export with the total amount/100, because I used euro prices with dot as cent seperator before.

I updated the documentation here, because I can't find any information in the release notes and I hope, that this will help future ugraders to avoid this mistake.

Best regards
Mathias