### PR TITLE
add batch booking option for credit transfer

### DIFF
--- a/doc/direct_credit.md
+++ b/doc/direct_credit.md
@@ -18,9 +18,8 @@ $customerCredit->addPaymentInfo('firstPayment', array(
 // Add/Set batch booking option, you can pass boolean value as per your requirement
 $customerCredit->setBatchBooking(true);
 // Add a Single Transaction to the named payment
-// `amount` should be in cents
 $customerCredit->addTransfer('firstPayment', array(
-    'amount'                  => 500,
+    'amount'                  => 500, // `amount` should be in cents
     'creditorIban'            => 'FI1350001540000056',
     'creditorBic'             => 'OKOYFIHH',
     'creditorName'            => 'Their Company',

--- a/doc/direct_credit.md
+++ b/doc/direct_credit.md
@@ -15,7 +15,10 @@ $customerCredit->addPaymentInfo('firstPayment', array(
     'debtorAccountIBAN'       => 'FI1350001540000056',
     'debtorAgentBIC'          => 'PSSTFRPPMON',
 ));
+// Add/Set batch booking option, you can pass boolean value as per your requirement
+$customerCredit->setBatchBooking(true);
 // Add a Single Transaction to the named payment
+// `amount` should be in cents
 $customerCredit->addTransfer('firstPayment', array(
     'amount'                  => 500,
     'creditorIban'            => 'FI1350001540000056',

--- a/doc/direct_debit.md
+++ b/doc/direct_debit.md
@@ -20,7 +20,10 @@ $directDebit->addPaymentInfo('firstPayment', array(
     'creditorId'            => 'DE21WVM1234567890',
     'localInstrumentCode'   => 'CORE' // default. optional.
 ));
+// Add/Set batch booking option, you can pass boolean value as per your requirement
+$directDebit->setBatchBooking(true);
 // Add a Single Transaction to the named payment
+// `amount` should be in cents
 $directDebit->addTransfer('firstPayment', array(
     'amount'                => 500,
     'debtorIban'            => 'FI1350001540000056',

--- a/doc/direct_debit.md
+++ b/doc/direct_debit.md
@@ -23,9 +23,8 @@ $directDebit->addPaymentInfo('firstPayment', array(
 // Add/Set batch booking option, you can pass boolean value as per your requirement
 $directDebit->setBatchBooking(true);
 // Add a Single Transaction to the named payment
-// `amount` should be in cents
 $directDebit->addTransfer('firstPayment', array(
-    'amount'                => 500,
+    'amount'                => 500, // `amount` should be in cents
     'debtorIban'            => 'FI1350001540000056',
     'debtorBic'             => 'OKOYFIHH',
     'debtorName'            => 'Their Company',

--- a/src/TransferFile/Facade/CustomerCreditFacade.php
+++ b/src/TransferFile/Facade/CustomerCreditFacade.php
@@ -37,6 +37,11 @@ class CustomerCreditFacade extends BaseCustomerTransferFileFacade
             $originAgentBic,
             $paymentInformation['debtorName']
         );
+
+        if (isset($paymentInformation['batchBooking'])) {
+            $payment->setBatchBooking($paymentInformation['batchBooking']);
+        }
+
         $payment->setDueDate($this->createDueDateFromPaymentInformation($paymentInformation));
 
         $this->payments[$paymentName] = $payment;


### PR DESCRIPTION
Pull request has following changes
* Add option for batch booking for credit transfer, previously this option was available only for debit transfer but with this pull request, we can set `batch booking` for credit transfer as well.
* Update doc (mention that amount is in cents)