### PR TITLE
Fix documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
 - Add throws tag [\#100](https://github.com/php-sepa-xml/php-sepa-xml/pull/100) ([VincentLanglet](https://github.com/VincentLanglet))
 - Increase php versions to run tests for [\#97](https://github.com/php-sepa-xml/php-sepa-xml/pull/97) ([monofone](https://github.com/monofone))
 
+**Important changes:**
+
+- The direct debit transfer amount has been changed from string to int. You must add the amount as integer cent values, otherwise the SEPA export may contain wrong amounts.
+
 ## [1.6.2](https://github.com/php-sepa-xml/php-sepa-xml/tree/1.6.2) (2020-02-13)
 
 [Full Changelog](https://github.com/php-sepa-xml/php-sepa-xml/compare/1.6.1...1.6.2)

--- a/doc/direct_credit.md
+++ b/doc/direct_credit.md
@@ -14,9 +14,10 @@ $customerCredit->addPaymentInfo('firstPayment', array(
     'debtorName'              => 'My Company',
     'debtorAccountIBAN'       => 'FI1350001540000056',
     'debtorAgentBIC'          => 'PSSTFRPPMON',
+    // Add/Set batch booking option, you can pass boolean value as per your requirement, optional
+    'batchBooking'            => true, 
 ));
-// Add/Set batch booking option, you can pass boolean value as per your requirement
-$customerCredit->setBatchBooking(true);
+
 // Add a Single Transaction to the named payment
 $customerCredit->addTransfer('firstPayment', array(
     'amount'                  => 500, // `amount` should be in cents

--- a/doc/direct_debit.md
+++ b/doc/direct_debit.md
@@ -19,9 +19,10 @@ $directDebit->addPaymentInfo('firstPayment', array(
     'seqType'               => PaymentInformation::S_ONEOFF,
     'creditorId'            => 'DE21WVM1234567890',
     'localInstrumentCode'   => 'CORE' // default. optional.
+    // Add/Set batch booking option, you can pass boolean value as per your requirement, optional
+    'batchBooking'          => true, 
 ));
-// Add/Set batch booking option, you can pass boolean value as per your requirement
-$directDebit->setBatchBooking(true);
+
 // Add a Single Transaction to the named payment
 $directDebit->addTransfer('firstPayment', array(
     'amount'                => 500, // `amount` should be in cents

--- a/src/TransferFile/Facade/CustomerCreditFacade.php
+++ b/src/TransferFile/Facade/CustomerCreditFacade.php
@@ -19,7 +19,8 @@ class CustomerCreditFacade extends BaseCustomerTransferFileFacade
      *             debtorName: string,
      *             debtorAccountIBAN: string,
      *             debtorAgentBIC?: string,
-     *             dueDate?: string|\DateTime
+     *             dueDate?: string|\DateTime,
+     *             batchBooking?: bool
      *             } $paymentInformation
      *
      * @throws InvalidArgumentException


### PR DESCRIPTION
The example markdown shows the availablity of ->setBatchBooking() in the credit and debit facade, but this method is not callable in $customerCredit/directDebit Facade, only if you assign the PaymentInformation  instance, returned by addPaymentInfo().