### PR TITLE
Add issuer for Belgian banks

### DIFF
--- a/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -240,6 +240,11 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
             $orgId = $this->createElement('OrgId');
             $othr  = $this->createElement('Othr');
             $othr->appendChild($this->createElement('Id', $groupHeader->getInitiatingPartyId()));
+
+            if ($groupHeader->getIssuer()) {
+                $othr->appendChild($this->createElement('Issr', $groupHeader->getIssuer()));
+            }
+
             $orgId->appendChild($othr);
             $newId->appendChild($orgId);
 


### PR DESCRIPTION
For Belgian banks the issuer of the organisation id must be present.