### PR TITLE
PHP 8.1 deprecation warning

### DIFF
--- a/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -187,12 +187,12 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
         $debtorAccount->appendChild($this->getIbanElement($transactionInformation->getIban()));
         $directDebitTransactionInformation->appendChild($debtorAccount);
 
-        if (strlen($transactionInformation->getCreditorReference()) > 0)
+        if (strlen((string)$transactionInformation->getCreditorReference()) > 0)
         {
             $directDebitTransactionInformation->appendChild(
                 $this->getStructuredRemittanceElement($transactionInformation)
             );
-        } elseif (strlen($transactionInformation->getRemittanceInformation()) > 0) {
+        } elseif (strlen((string)$transactionInformation->getRemittanceInformation()) > 0) {
             $directDebitTransactionInformation->appendChild(
                 $this->getRemittenceElement($transactionInformation->getRemittanceInformation())
             );


### PR DESCRIPTION
PHP 8.1 throws a deprecation warning if null is passed to strlen function.
A cast to string solves this issue.
It would also be possible to check for null instead of casting right before the function call of strlen.