### PR TITLE
PHP 8.1 deprecation warning in visitTransferInformation

### DIFF
--- a/src/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -175,11 +175,11 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         $CdtTrfTxInf->appendChild($creditorAccount);
 
         // remittance 2.98 2.99
-        if (strlen($transactionInformation->getCreditorReference()) > 0)
+        if (strlen((string)$transactionInformation->getCreditorReference()) > 0)
         {
             $remittanceInformation = $this->getStructuredRemittanceElement($transactionInformation);
             $CdtTrfTxInf->appendChild($remittanceInformation);
-        } elseif (strlen($transactionInformation->getRemittanceInformation()) > 0) {
+        } elseif (strlen((string)$transactionInformation->getRemittanceInformation()) > 0) {
             $remittanceInformation = $this->getRemittenceElement($transactionInformation->getRemittanceInformation());
             $CdtTrfTxInf->appendChild($remittanceInformation);
         }


### PR DESCRIPTION
PHP 8.1 throws a deprecation warning if null is passed to strlen function.
A cast to string solves this issue.

It would also be possible to check for null instead of casting right before the function call of strlen.