### PR TITLE
Added support for debitor's structured address data (street name, post code, etc.)

### DIFF
--- a/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -124,6 +124,10 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
      */
     public function visitTransferInformation(TransferInformationInterface $transactionInformation): void
     {
+        if (!isset($this->currentPayment)) {
+            throw new \LogicException('Payment information have to be added before any transaction informations can be added.');
+        }
+
         /** @var  $transactionInformation CustomerDirectDebitTransferInformation */
         $directDebitTransactionInformation = $this->createElement('DrctDbtTxInf');
 

--- a/src/TransferInformation/BaseTransferInformation.php
+++ b/src/TransferInformation/BaseTransferInformation.php
@@ -91,11 +91,58 @@ class BaseTransferInformation implements TransferInformationInterface
     protected $creditorReference;
 
     /**
+     * Nation with its own government.
+     *
+     * The code is checked against the list of country names obtained from the
+     * United Nations (ISO 3166, Alpha-2 code).
+     *
      * @var string|null
      */
     protected $country;
 
     /**
+     * Name of a built-up area, with defined boundaries, and a local government.
+     *
+     * Maximum allowed length is 35 characters.
+     *
+     * @var string|null
+     */
+    protected $townName;
+
+    /**
+     * Identifier consisting of a group of letters and/or numbers that is added
+     * to a postal address to assist the sorting of mail.
+     *
+     * Maximum allowed length is 16 characters.
+     *
+     * @var string|null
+     */
+    protected $postCode;
+
+    /**
+     * Name of a street or thoroughfare.
+     *
+     * Maximum allowed length is 70 characters.
+     *
+     * @var string|null
+     */
+    protected $streetName;
+
+    /**
+     * Number that identifies the position of a building on a street.
+     *
+     * Maximum allowed length is 16 characters.
+     *
+     * @var string|null
+     */
+    protected $buildingNumber;
+
+    /**
+     * Information that locates and identifies a specific address, as defined
+     * by postal services, presented in free format text.
+     *
+     * Maximum allowed length is 70 characters.
+     *
      * @var string|string[]|null
      */
     protected $postalAddress;
@@ -208,6 +255,106 @@ class BaseTransferInformation implements TransferInformationInterface
     public function setCountry(string $country): void
     {
         $this->country = $country;
+    }
+
+    /**
+     * Get the name of the town where the creditor/debtor is located
+     *
+     * Maximum allowed length is 35 characters.
+     *
+     * @return string|null
+     */
+    public function getTownName(): ?string
+    {
+        return $this->townName;
+    }
+
+    /**
+     * Set the name of the town where the creditor/debtor is located.
+     *
+     * @param string|null $townName Maximum allowed length is 35 characters.
+     */
+    public function setTownName(?string $townName): void
+    {
+        if (null === $townName) {
+            $this->townName = null;
+        } else {
+            $this->townName = StringHelper::sanitizeString($townName);
+        }
+    }
+
+    /**
+     * Get the post code where the creditor/debtor is located.
+     *
+     * @return string|null
+     */
+    public function getPostCode(): ?string
+    {
+        return $this->postCode;
+    }
+
+    /**
+     * Set the post code where the creditor/debtor is located.
+     *
+     * @param string|null $postCode Maximum allowed length is 16 characters.
+     */
+    public function setPostCode(?string $postCode): void
+    {
+        if (null === $postCode) {
+            $this->postCode = null;
+        } else {
+            $this->postCode = StringHelper::sanitizeString($postCode);
+        }
+    }
+
+    /**
+     * Get the street name where the creditor/debtor is located.
+     *
+     * @return string|null
+     */
+    public function getStreetName(): ?string
+    {
+        return $this->streetName;
+    }
+
+    /**
+     * Set the street name where the creditor/debtor is located.
+     *
+     * @param string|null $streetName Maximum allowed length is 70 characters.
+     */
+    public function setStreetName(?string $streetName): void
+    {
+        if (null === $streetName) {
+            $this->streetName = null;
+        } else {
+            $this->streetName = StringHelper::sanitizeString($streetName);
+        }
+    }
+
+    /**
+     * Get the number that identifies the position of the building on the street
+     * where the creditor/debtor is located.
+     *
+     * @return string|null
+     */
+    public function getBuildingNumber(): ?string
+    {
+        return $this->buildingNumber;
+    }
+
+    /**
+     * Set the number that identifies the position of the building on the street
+     * where the creditor/debtor is located.
+     *
+     * @param string|null $buildingNumber Maximum allowed length is 16 characters.
+     */
+    public function setBuildingNumber(?string $buildingNumber): void
+    {
+        if (null === $buildingNumber) {
+            $this->buildingNumber = null;
+        } else {
+            $this->buildingNumber = StringHelper::sanitizeString($buildingNumber);
+        }
     }
 
     /**

--- a/tests/Unit/DomBuilder/CustomerDirectDebitTransferDomBuilderTest.php
+++ b/tests/Unit/DomBuilder/CustomerDirectDebitTransferDomBuilderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Scripting/PHPClass.php to edit this template
+ */
+
+namespace Digitick\Sepa\Tests\Unit\DomBuilder;
+
+use Digitick\Sepa\DomBuilder\CustomerDirectDebitTransferDomBuilder;
+use Digitick\Sepa\GroupHeader;
+
+use PHPUnit\Framework\TestCase;
+
+class CustomerDirectDebitTransferDomBuilderTest extends TestCase
+{
+    /**
+     * Test the XML generation of a direct debit transfer with structured address
+     * data for pain.008.001.02
+     */
+    public function testWithAddress(): void
+    {
+        $groupHeader = new GroupHeader('TEST_DEBTOR_ADRESS', 'Test Company Inc.');
+        $groupHeader->setInitiatingPartyId('DE67ZZZ00000123456');
+
+        $paymentInformation = new \Digitick\Sepa\PaymentInformation('RAND001', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Test Company Inc.');
+        $paymentInformation->setCreditorId('DE67ZZZ00000123456');
+        $paymentInformation->setSequenceType('FRST');
+
+        $transferFile = new \Digitick\Sepa\TransferFile\CustomerDirectDebitTransferFile($groupHeader);
+        $transferFile->addPaymentInformation($paymentInformation);
+
+        $transactionInformation = new \Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation(1000, 'DE40500105174181777145', 'Max Musterman');
+        $transactionInformation->setMandateId('TEST-MANDATE-1');
+        $transactionInformation->setMandateSignDate(new \DateTime('2022-05-15'));
+        $transactionInformation->setCountry('DE');
+        $transactionInformation->setPostCode('60431');
+        $transactionInformation->setTownName('Frankfurt am Main');
+        $transactionInformation->setStreetName('Wilhelm-Epstein-Str.');
+        $transactionInformation->setBuildingNumber('14');
+
+        $builder = new CustomerDirectDebitTransferDomBuilder('pain.008.001.02');
+        $builder->visitTransferFile($transferFile);
+        $builder->visitGroupHeader($groupHeader);
+        $builder->visitPaymentInformation($paymentInformation);
+        $builder->visitTransferInformation($transactionInformation);
+
+        $xml = $builder->asXml();
+
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($xml);
+
+        // Test xml schema validation
+
+        $validated = $doc->schemaValidate(__DIR__ . '/../../fixtures/pain.008.001.02.xsd');
+        $this->assertTrue($validated);
+
+        // Test contents
+
+        $xpath = new \DOMXPath($doc);
+        $xpath->registerNamespace('ns', 'urn:iso:std:iso:20022:tech:xsd:pain.008.001.02');
+
+        $postalAddressNode = $xpath->evaluate('/ns:Document/ns:CstmrDrctDbtInitn/ns:PmtInf/ns:DrctDbtTxInf/ns:Dbtr/ns:PstlAdr')->item(0);
+
+        $this->assertSame('DE', $xpath->evaluate('./ns:Ctry', $postalAddressNode)->item(0)->textContent);
+        $this->assertSame('60431', $xpath->evaluate('./ns:PstCd', $postalAddressNode)->item(0)->textContent);
+        $this->assertSame('Frankfurt am Main', $xpath->evaluate('./ns:TwnNm', $postalAddressNode)->item(0)->textContent);
+        $this->assertSame('Wilhelm-Epstein-Str.', $xpath->evaluate('./ns:StrtNm', $postalAddressNode)->item(0)->textContent);
+        $this->assertSame('14', $xpath->evaluate('./ns:BldgNb', $postalAddressNode)->item(0)->textContent);
+    }
+}


### PR DESCRIPTION
Currently the direct debit transfer DOM builder only supports the free format address line (`AdrLine`) which is not accepted by our bank, when we want to direct debit from a Swiss bank account (debtor address is mandatory when the debtor PSP is located in a non-EEA SEPA country or territory).

So I have extended the `BaseTransferInformation` class with the attributes `townName`, `postCode`, `streetName` and `buildingNumber` and their matching getters and setters.

Additionally I have extended the `CustomerDirectDebitTransferDomBuilder` to add those data to the XML according to the official specification of the *ISO 20022* standard.
The specification can be found [here](https://www.iso20022.org/catalogue-messages/iso-20022-messages-archive?search=pain.008.001.02)

Currently this is done for *pain.008.001.02*. The informal *pain.008.003.02* does not support this data.

A unit test that makes sure that the addition corresponds to the XSD was added, too.