### PR TITLE
Fixed `getNumberOfTransactions()` type for `BaseDomBuilder::createElement`

### DIFF
--- a/src/DomBuilder/BaseDomBuilder.php
+++ b/src/DomBuilder/BaseDomBuilder.php
@@ -110,7 +110,7 @@ abstract class BaseDomBuilder implements DomBuilderInterface
             $groupHeader->getCreationDateTime()->format($groupHeader->getCreationDateTimeFormat())
         );
         $groupHeaderTag->appendChild($creationDateTime);
-        $groupHeaderTag->appendChild($this->createElement('NbOfTxs', $groupHeader->getNumberOfTransactions()));
+        $groupHeaderTag->appendChild($this->createElement('NbOfTxs', (string)$groupHeader->getNumberOfTransactions()));
         $groupHeaderTag->appendChild(
             $this->createElement('CtrlSum', $this->intToCurrency($groupHeader->getControlSumCents()))
         );

--- a/src/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -62,7 +62,7 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         }
 
         $this->currentPayment->appendChild(
-            $this->createElement('NbOfTxs', $paymentInformation->getNumberOfTransactions())
+            $this->createElement('NbOfTxs', (string)$paymentInformation->getNumberOfTransactions())
         );
 
         $this->currentPayment->appendChild(

--- a/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -59,7 +59,7 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
         }
 
         $this->currentPayment->appendChild(
-            $this->createElement('NbOfTxs', $paymentInformation->getNumberOfTransactions())
+            $this->createElement('NbOfTxs', (string)$paymentInformation->getNumberOfTransactions())
         );
 
         $this->currentPayment->appendChild(


### PR DESCRIPTION
Fixed some type errors. 
`BaseDomBuilder::createElement` expects argument #2 to be `string` but `getNumberOfTransactions()` returns `int`