### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,34 @@
+name: PHPStan
+
+on:
+  pull_request:
+    branches: [ "testing" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --no-progress  --ansi
+
+    - name: Run phpstan
+      run: composer run-script phpstan

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,36 @@
+name: PHPUnit
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --no-progress --ansi
+
+    - name: Run test suite
+      run: composer run-script phpunit

--- a/.github/workflows/rectorci.yml
+++ b/.github/workflows/rectorci.yml
@@ -1,0 +1,39 @@
+# Checks code with Rector and auto-commits
+name: RectorCI
+
+on:
+#  pull_request: null
+  pull_request:
+    branches: ["testing"]
+
+jobs:
+  rector:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      -
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/checkout@v3
+        with:
+          # Must be used to trigger workflow after push
+          token: ${{ secrets.ACCESS_TOKEN }}
+
+      -
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-progress --ansi
+
+      - name: Run Rector
+        run: bin/rector --ansi
+
+      -
+        # commit only to core contributors who have repository access
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: '[rector] Rector fixes'
+          commit_author: 'GitHub Action <actions@github.com>'
+          commit_user_email: 'action@github.com'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 php-sepa-xml
 ============
 
-Master: [![Build Status](https://api.travis-ci.org/php-sepa-xml/php-sepa-xml.png?branch=master)](http://travis-ci.org/php-sepa-xml/php-sepa-xml)
+Master: [![Build Status](https://github.com/BorislavSabev/php-sepa-xml/actions/workflows/phpunit.yml/badge.svg)](https://github.com/BorislavSabev/php-sepa-xml/actions/workflows/phpunit.yml)
 
 SEPA file generator for PHP.
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 3
+	level: 2
 	paths:
 		- src
 		- rector.php

--- a/rector.php
+++ b/rector.php
@@ -3,12 +3,18 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\Set\ValueObject\SetList;
 
 return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/src',
         __DIR__ . '/tests',
+        __DIR__ . '/rector.php'
     ])
     // uncomment to reach your current PHP version
-    // ->withPhpSets()
+    ->withSets([
+        SetList::PHP_72,
+        LevelSetList::UP_TO_PHP_72
+    ])
     ->withTypeCoverageLevel(0);


### PR DESCRIPTION
# Changelog

Migrate to GitHub Actions in order to:
- Run PHPUnit
- Run PHPStan
- Run rector with auto-commit

## Added
- phpunit workflow
- phpstan workflow
- rectorci workflow

phpstan and rectorci intentionally point to the "testing" branch for now as we need to clean parts of the code before enabling them.

## Removed
- Travis CI badge
Replaced it with a GH Actions badge and removed the old webhook to it.

There are a few more things to fixup for e.g. the badge needs to be re-created on this repository. I will take care of them when merging.
