### PR TITLE
Make all test data provider methods static

### DIFF
--- a/tests/Functional/CustomerCreditValidationPain00100103Test.php
+++ b/tests/Functional/CustomerCreditValidationPain00100103Test.php
@@ -100,7 +100,7 @@ class CustomerCreditValidationPain00100103Test extends TestCase
         $this->assertTrue($validated);
     }
 
-    public function scenarios(): iterable
+    public static function scenarios(): iterable
     {
         return [
             [

--- a/tests/Functional/CustomerCreditValidationTest.php
+++ b/tests/Functional/CustomerCreditValidationTest.php
@@ -512,7 +512,7 @@ class CustomerCreditValidationTest extends TestCase
 
     }
 
-    public function provideSchema(): iterable
+    public static function provideSchema(): iterable
     {
         return [
             ["pain.001.001.03"],
@@ -521,7 +521,7 @@ class CustomerCreditValidationTest extends TestCase
         ];
     }
 
-    public function provideAddressTests(): iterable
+    public static function provideAddressTests(): iterable
     {
         return [
             [['CH', ['Teststreet 1', '21345 Somewhere']]],

--- a/tests/Functional/CustomerDirectDebitValidationTest.php
+++ b/tests/Functional/CustomerDirectDebitValidationTest.php
@@ -231,7 +231,7 @@ class CustomerDirectDebitValidationTest extends TestCase
         $this->assertEquals('Only A-Z without aeoeuessAeOeUe creditorSchemeId', $testNode->item(0)->textContent);
     }
 
-    public function provideSchema(): iterable
+    public static function provideSchema(): iterable
     {
         return [
             ['pain.008.001.02'],
@@ -281,7 +281,7 @@ class CustomerDirectDebitValidationTest extends TestCase
         $this->assertTrue($validated);
     }
 
-    public function scenarios(): iterable
+    public static function scenarios(): iterable
     {
         $scenarios = [];
         foreach (['pain.008.001.02','pain.008.002.02','pain.008.003.02'] as $pain) {

--- a/tests/TestFileSanityCheckTest.php
+++ b/tests/TestFileSanityCheckTest.php
@@ -49,7 +49,7 @@ class TestFileSanityCheckTest extends TestCase
         $this->assertTrue($validated);
     }
 
-    public function painProvider(): iterable
+    public static function painProvider(): iterable
     {
         return [
             ['pain.001.001.03'],

--- a/tests/Unit/TransferFile/Facade/CustomerCreditFacadeTest.php
+++ b/tests/Unit/TransferFile/Facade/CustomerCreditFacadeTest.php
@@ -82,7 +82,7 @@ class CustomerCreditFacadeTest extends TestCase
         $this->assertTrue($dom->schemaValidate(__DIR__ . "/../../../fixtures/" . $schema . ".xsd"));
     }
 
-    public function schemaProvider(): iterable
+    public static function schemaProvider(): iterable
     {
         return [
             ["pain.001.001.03"],
@@ -91,7 +91,7 @@ class CustomerCreditFacadeTest extends TestCase
         ];
     }
 
-    public function schemaProviderEmptyBic(): iterable
+    public static function schemaProviderEmptyBic(): iterable
     {
         return [
             ["pain.001.001.03"],

--- a/tests/Unit/TransferFile/Facade/CustomerDirectDebitFacadeTest.php
+++ b/tests/Unit/TransferFile/Facade/CustomerDirectDebitFacadeTest.php
@@ -236,7 +236,7 @@ class CustomerDirectDebitFacadeTest extends TestCase
         $this->assertTrue($this->dom->schemaValidate(__DIR__ . '/../../../fixtures/' . $schema . '.xsd'));
     }
 
-    public function provideSchema(): iterable
+    public static function provideSchema(): iterable
     {
         return [
             ['pain.008.001.02'],


### PR DESCRIPTION
PHPUnit deprecated non-static test data providers. This PR fixes the deprecation messages