### PR TITLE
Allow custom sanitization of strings.

### DIFF
--- a/doc/direct_debit.md
+++ b/doc/direct_debit.md
@@ -81,7 +81,7 @@ $directDebit->addTransfer('firstPayment', array(
     'debtorIban'            => 'FI1350001540000056',
     'debtorBic'             => 'OKOYFIHH',
     'debtorName'            => 'Their Company',
-    'debtorMandate'         =>  'AB12345',
+    'debtorMandate'         => 'AB12345',
     'debtorMandateSignDate' => '13.10.2012',
     'remittanceInformation' => 'Purpose of this direct debit',
     'endToEndId'            => 'Invoice-No X' // optional, if you want to provide additional structured info

--- a/doc/string_sanitization.md
+++ b/doc/string_sanitization.md
@@ -1,0 +1,31 @@
+## Custom String Sanitization
+
+By default, this package sanitizes strings using an internal helper method — `StringHelper::sanitizeString()` — to ensure safe and valid output for SEPA XML.
+
+If the default sanitization doesn't suit your needs, you can override it globally using the `Sanitizer::setSanitizer()` method.
+
+Note: XML entities (like `<`, `>`, `&`, etc.) will still be escaped separately. This customization affects **pre-processing** before XML generation.
+
+### Example: Custom Sanitization
+```php
+use SepaXml\Util\Sanitizer;
+
+// Change the global sanitizer to a custom implementation
+Sanitizer::setSanitizer(fn(string $value): string => strtoupper($value));
+```
+
+### Example: Disable Sanitization
+```php
+use SepaXml\Util\Sanitizer;
+
+// Disable the sanitizer globally
+Sanitizer::disableSanitizer();
+```
+
+### Reset Sanitization
+```php
+use SepaXml\Util\Sanitizer;
+
+// Reset the sanitizer to its default behavior
+Sanitizer::resetSanitizer();
+```

--- a/doc/string_sanitization.md
+++ b/doc/string_sanitization.md
@@ -11,7 +11,9 @@ Note: XML entities (like `<`, `>`, `&`, etc.) will still be escaped separately. 
 use SepaXml\Util\Sanitizer;
 
 // Change the global sanitizer to a custom implementation
-Sanitizer::setSanitizer(fn(string $value): string => strtoupper($value));
+Sanitizer::setSanitizer(function (string $value): string {
+    return strtoupper($value);
+});
 ```
 
 ### Example: Disable Sanitization

--- a/src/GroupHeader.php
+++ b/src/GroupHeader.php
@@ -25,7 +25,7 @@ namespace Digitick\Sepa;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Digitick\Sepa\DomBuilder\DomBuilderInterface;
-use Digitick\Sepa\Util\StringHelper;
+use Digitick\Sepa\Util\Sanitizer;
 
 class GroupHeader
 {
@@ -97,7 +97,7 @@ class GroupHeader
     {
         $this->messageIdentification = $messageIdentification;
         $this->isTest = $isTest;
-        $this->initiatingPartyName = StringHelper::sanitizeString($initiatingPartyName);
+        $this->initiatingPartyName = Sanitizer::sanitize($initiatingPartyName);
         $this->creationDateTime = new DateTimeImmutable();
     }
 
@@ -128,7 +128,7 @@ class GroupHeader
 
     public function setInitiatingPartyIdentificationScheme(string $scheme): void
     {
-        $this->initiatingPartyIdentificationScheme = StringHelper::sanitizeString($scheme);
+        $this->initiatingPartyIdentificationScheme = Sanitizer::sanitize($scheme);
     }
 
     public function getInitiatingPartyIdentificationScheme(): ?string
@@ -148,7 +148,7 @@ class GroupHeader
 
     public function setInitiatingPartyName(string $initiatingPartyName): void
     {
-        $this->initiatingPartyName = StringHelper::sanitizeString($initiatingPartyName);
+        $this->initiatingPartyName = Sanitizer::sanitize($initiatingPartyName);
     }
 
     public function getInitiatingPartyName(): string

--- a/src/PaymentInformation.php
+++ b/src/PaymentInformation.php
@@ -27,7 +27,7 @@ use DateTimeInterface;
 use Digitick\Sepa\DomBuilder\DomBuilderInterface;
 use Digitick\Sepa\Exception\InvalidArgumentException;
 use Digitick\Sepa\TransferInformation\TransferInformationInterface;
-use Digitick\Sepa\Util\StringHelper;
+use Digitick\Sepa\Util\Sanitizer;
 
 class PaymentInformation
 {
@@ -171,7 +171,7 @@ class PaymentInformation
         $this->id = $id;
         $this->originAccountIBAN = $originAccountIBAN;
         $this->originAgentBIC = $originAgentBIC;
-        $this->originName = StringHelper::sanitizeString($originName);
+        $this->originName = Sanitizer::sanitize($originName);
         $this->originAccountCurrency = $originAccountCurrency;
         $this->dueDate = new DateTimeImmutable();
     }
@@ -289,7 +289,7 @@ class PaymentInformation
 
     public function setOriginName(string $originName): void
     {
-        $this->originName = StringHelper::sanitizeString($originName);
+        $this->originName = Sanitizer::sanitize($originName);
     }
 
     public function getOriginName(): string
@@ -299,7 +299,7 @@ class PaymentInformation
 
     public function setOriginBankPartyIdentification(string $id): void
     {
-        $this->originBankPartyIdentification = StringHelper::sanitizeString($id);
+        $this->originBankPartyIdentification = Sanitizer::sanitize($id);
     }
 
     public function getOriginBankPartyIdentification(): ?string
@@ -309,7 +309,7 @@ class PaymentInformation
 
     public function setOriginBankPartyIdentificationScheme(string $scheme): void
     {
-        $this->originBankPartyIdentificationScheme = StringHelper::sanitizeString($scheme);
+        $this->originBankPartyIdentificationScheme = Sanitizer::sanitize($scheme);
     }
 
     public function getOriginBankPartyIdentificationScheme(): ?string
@@ -379,7 +379,7 @@ class PaymentInformation
 
     public function setCreditorId(string $creditorSchemeId): void
     {
-        $this->creditorId = StringHelper::sanitizeString($creditorSchemeId);
+        $this->creditorId = Sanitizer::sanitize($creditorSchemeId);
     }
 
     public function getCreditorId(): ?string

--- a/src/TransferInformation/BaseTransferInformation.php
+++ b/src/TransferInformation/BaseTransferInformation.php
@@ -24,7 +24,7 @@ namespace Digitick\Sepa\TransferInformation;
 
 use Digitick\Sepa\DomBuilder\DomBuilderInterface;
 use Digitick\Sepa\Exception\InvalidArgumentException;
-use Digitick\Sepa\Util\StringHelper;
+use Digitick\Sepa\Util\Sanitizer;
 
 class BaseTransferInformation implements TransferInformationInterface
 {
@@ -165,8 +165,8 @@ class BaseTransferInformation implements TransferInformationInterface
 
         $this->transferAmount = $amount;
         $this->iban = $iban;
-        $this->name = StringHelper::sanitizeString($name);
-        $this->EndToEndIdentification = StringHelper::sanitizeString($identification);
+        $this->name = Sanitizer::sanitize($name);
+        $this->EndToEndIdentification = Sanitizer::sanitize($identification);
     }
 
     public function accept(DomBuilderInterface $domBuilder): void
@@ -191,7 +191,7 @@ class BaseTransferInformation implements TransferInformationInterface
 
     public function setEndToEndIdentification(string $EndToEndIdentification): void
     {
-        $this->EndToEndIdentification = StringHelper::sanitizeString($EndToEndIdentification);
+        $this->EndToEndIdentification = Sanitizer::sanitize($EndToEndIdentification);
     }
 
     public function getEndToEndIdentification(): string
@@ -226,7 +226,7 @@ class BaseTransferInformation implements TransferInformationInterface
 
     public function setCreditorReference(string $creditorReference): void
     {
-        $this->creditorReference = StringHelper::sanitizeString($creditorReference);
+        $this->creditorReference = Sanitizer::sanitize($creditorReference);
     }
 
     public function getCreditorReference(): ?string
@@ -236,7 +236,7 @@ class BaseTransferInformation implements TransferInformationInterface
 
     public function setCreditorReferenceType(string $creditorReferenceType): void
     {
-        $this->creditorReferenceType = StringHelper::sanitizeString($creditorReferenceType);
+        $this->creditorReferenceType = Sanitizer::sanitize($creditorReferenceType);
     }
 
     public function getCreditorReferenceType(): ?string
@@ -256,7 +256,7 @@ class BaseTransferInformation implements TransferInformationInterface
 
     public function setRemittanceInformation(string $remittanceInformation): void
     {
-        $this->remittanceInformation = StringHelper::sanitizeString($remittanceInformation);
+        $this->remittanceInformation = Sanitizer::sanitize($remittanceInformation);
     }
 
     public function getRemittanceInformation(): ?string
@@ -296,7 +296,7 @@ class BaseTransferInformation implements TransferInformationInterface
         if (null === $townName) {
             $this->townName = null;
         } else {
-            $this->townName = StringHelper::sanitizeString($townName);
+            $this->townName = Sanitizer::sanitize($townName);
         }
     }
 
@@ -320,7 +320,7 @@ class BaseTransferInformation implements TransferInformationInterface
         if (null === $postCode) {
             $this->postCode = null;
         } else {
-            $this->postCode = StringHelper::sanitizeString($postCode);
+            $this->postCode = Sanitizer::sanitize($postCode);
         }
     }
 
@@ -344,7 +344,7 @@ class BaseTransferInformation implements TransferInformationInterface
         if (null === $streetName) {
             $this->streetName = null;
         } else {
-            $this->streetName = StringHelper::sanitizeString($streetName);
+            $this->streetName = Sanitizer::sanitize($streetName);
         }
     }
 
@@ -370,7 +370,7 @@ class BaseTransferInformation implements TransferInformationInterface
         if (null === $buildingNumber) {
             $this->buildingNumber = null;
         } else {
-            $this->buildingNumber = StringHelper::sanitizeString($buildingNumber);
+            $this->buildingNumber = Sanitizer::sanitize($buildingNumber);
         }
     }
 

--- a/src/TransferInformation/CustomerDirectDebitTransferInformation.php
+++ b/src/TransferInformation/CustomerDirectDebitTransferInformation.php
@@ -23,7 +23,7 @@
 namespace Digitick\Sepa\TransferInformation;
 
 use DateTimeInterface;
-use Digitick\Sepa\Util\StringHelper;
+use Digitick\Sepa\Util\Sanitizer;
 
 class CustomerDirectDebitTransferInformation extends BaseTransferInformation
 {
@@ -96,7 +96,7 @@ class CustomerDirectDebitTransferInformation extends BaseTransferInformation
 
     public function setOriginalMandateId(string $originalMandateId): void
     {
-        $this->originalMandateId = StringHelper::sanitizeString($originalMandateId);
+        $this->originalMandateId = Sanitizer::sanitize($originalMandateId);
     }
 
     public function getOriginalMandateId(): ?string
@@ -106,7 +106,7 @@ class CustomerDirectDebitTransferInformation extends BaseTransferInformation
 
     public function setMandateId(string $mandateId): void
     {
-        $this->mandateId = StringHelper::sanitizeString($mandateId);
+        $this->mandateId = Sanitizer::sanitize($mandateId);
     }
 
     public function getMandateId(): ?string

--- a/src/Util/Sanitizer.php
+++ b/src/Util/Sanitizer.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * SEPA file generator.
+ *
+ * @copyright © Digitick <www.digitick.net> 2012-2013
+ * @copyright © Blage <www.blage.net> 2013
+ * @license GNU Lesser General Public License v3.0
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Lesser Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Digitick\Sepa\Util;
+
+class Sanitizer
+{
+    /**
+     * @var (callable(string): string)|null
+     */
+    private static $callback = null;
+
+    /**
+     * Set the global sanitization strategy.
+     */
+    public static function setSanitizer(callable $callback): void
+    {
+        self::$callback = $callback;
+    }
+
+    /**
+     * Get the current sanitizer (with fallback to default).
+     */
+    public static function getSanitizer(): callable
+    {
+        return self::$callback ?? [StringHelper::class, 'sanitizeString'];
+    }
+
+    /**
+     * Apply sanitization.
+     */
+    public static function sanitize(string $value): string
+    {
+        return call_user_func(self::getSanitizer(), $value);
+    }
+
+    /**
+     * Disable the sanitizer.
+     */
+    public static function disableSanitizer(): void
+    {
+        self::$callback = fn(string $value): string => $value;
+    }
+
+    /**
+     * Reset the sanitizer to the default.
+     */
+    public static function resetSanitizer(): void
+    {
+        self::$callback = null;
+    }
+}

--- a/src/Util/Sanitizer.php
+++ b/src/Util/Sanitizer.php
@@ -58,7 +58,9 @@ class Sanitizer
      */
     public static function disableSanitizer(): void
     {
-        self::$callback = fn(string $value): string => $value;
+        self::$callback = function (string $value): string {
+            return $value;
+        };
     }
 
     /**

--- a/tests/Unit/Util/SanitizerTest.php
+++ b/tests/Unit/Util/SanitizerTest.php
@@ -61,7 +61,9 @@ class SanitizerTest extends TestCase
     {
         $string = "Az09#_<&*:?,-/(+.)' ";
 
-        Sanitizer::setSanitizer(fn(string $value): string => strtoupper($value));
+        Sanitizer::setSanitizer(function (string $value): string {
+            return strtoupper($value);
+        });
 
         $this->assertEquals("AZ09#_<&*:?,-/(+.)' ", Sanitizer::sanitize($string));
     }
@@ -73,7 +75,9 @@ class SanitizerTest extends TestCase
     {
         $string = "ÄÖÜäöüß";
 
-        Sanitizer::setSanitizer(fn(string $value): string => strtoupper($value));
+        Sanitizer::setSanitizer(function (string $value): string {
+            return strtoupper($value);
+        });
         Sanitizer::resetSanitizer();
 
         $this->assertEquals("AeOeUeaeoeuess", Sanitizer::sanitize($string));

--- a/tests/Unit/Util/SanitizerTest.php
+++ b/tests/Unit/Util/SanitizerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\Util;
+
+use Digitick\Sepa\Util\Sanitizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit test for Sanitizer class.
+ */
+class SanitizerTest extends TestCase
+{
+    /**
+     * Tests german characters' translation with default sanitizer.
+     */
+    public function testGermanCharacters(): void
+    {
+        $string = 'ÄÖÜäöüß';
+
+        $this->assertEquals('AeOeUeaeoeuess', Sanitizer::sanitize($string));
+    }
+
+    /**
+     * Tests some special characters' translation with default sanitizer.
+     */
+    public function testSpecialCharacters(): void
+    {
+        $string = "Az09#_<&*:?,-/(+.)' ";
+
+        $this->assertEquals("Az09     :?,-/(+.)' ", Sanitizer::sanitize($string));
+    }
+    
+    /**
+     * Tests german characters' translation with disabled sanitizer.
+     */
+    public function testGermanCharactersWithDisabledSanitizer(): void
+    {
+        $string = 'ÄÖÜäöüß';
+
+        Sanitizer::disableSanitizer();
+
+        $this->assertEquals('ÄÖÜäöüß', Sanitizer::sanitize($string));
+    }
+
+    /**
+     * Tests some special characters' translation with disabled sanitizer.
+     */
+    public function testSpecialCharactersWithDisabledSanitizer(): void
+    {
+        $string = "Az09#_<&*:?,-/(+.)' ";
+
+        Sanitizer::disableSanitizer();
+
+        $this->assertEquals("Az09#_<&*:?,-/(+.)' ", Sanitizer::sanitize($string));
+    }
+
+    /**
+     * Tests custom sanitizer.
+     */
+    public function testCustomSanitizer(): void
+    {
+        $string = "Az09#_<&*:?,-/(+.)' ";
+
+        Sanitizer::setSanitizer(fn(string $value): string => strtoupper($value));
+
+        $this->assertEquals("AZ09#_<&*:?,-/(+.)' ", Sanitizer::sanitize($string));
+    }
+
+    /**
+     * Tests reset sanitizer to default.
+     */
+    public function testResetSanitizer(): void
+    {
+        $string = "ÄÖÜäöüß";
+
+        Sanitizer::setSanitizer(fn(string $value): string => strtoupper($value));
+        Sanitizer::resetSanitizer();
+
+        $this->assertEquals("AeOeUeaeoeuess", Sanitizer::sanitize($string));
+    }
+}


### PR DESCRIPTION
Hi guys,

I'm currently working on integrating this package with our banking system and needed the generated XML to exactly match the format our bank expects. I had to implement a few changes that I believe could also benefit others using the package.

Currently, string sanitization in the package replaces special characters like ü, &, etc. — for example, `Jürgen & Sohn` becomes `Juergen   Sohn`. However, in many cases, XML entity escaping is sufficient, and users might want to preserve the original characters or apply a custom transformation instead (like setting `&` to `and` or `und` or `y`).

To support this, I added the ability to override the default string sanitization logic globally via a static method

This makes it easier to:
 - Disable sanitization entirely with disableSanitizer()
 - Customize sanitization to fit specific bank requirements (e.g. replacing `&` with `and`, uppercasing or preserving accented characters)
 - There's also a resetSanitizer() method to revert to default behavior.

Tests were added and I already tested on my own project.

Let me know what do you think

Thanks!