### PR TITLE
Hotfix ramsey/uuid version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require": {
         "ext-dom": "*",
         "php": ">=7.2",
-        "ramsey/uuid": "4.2.*"
+        "ramsey/uuid": "^4.2.3"
     },
     "require-dev": {
         "ext-xml": "*",


### PR DESCRIPTION
# Changelog
## Changed
- HotFix ramsey/uuid version constraint definition as to not block v2.3.0 from installing on platforms >= php 8.1 as explained in #200 