### PR TITLE
Allow id in $paymentInformation to be a string

### DIFF
--- a/src/TransferFile/Facade/CustomerCreditFacade.php
+++ b/src/TransferFile/Facade/CustomerCreditFacade.php
@@ -17,7 +17,7 @@ class CustomerCreditFacade extends BaseCustomerTransferFileFacade
     /**
      * @param string $paymentName
      * @param array{
-     *     id: int,
+     *     id: string,
      *     debtorName: string,
      *     debtorAccountIBAN: string,
      *     debtorAgentBIC?: string,


### PR DESCRIPTION
In #186, the `$paymentInformation['id']` field's type was changed from `string` to `int`. I believe this was an accident, given that all methods that this value is being passed to accepts strings. Ultimately, the value is used in the `<PmtInfId>` element, which is not documented to be an integer.