### PR TITLE
Allow debtorAdrLine in `$transferInformation` to be an array

### DIFF
--- a/src/TransferFile/Facade/CustomerDirectDebitFacade.php
+++ b/src/TransferFile/Facade/CustomerDirectDebitFacade.php
@@ -95,7 +95,7 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
      *     buildingNumber?: string,
      *     floorNumber?: string,
      *     debtorCountry?: string,
-     *     debtorAdrLine?: string,
+     *     debtorAdrLine?: string|string[],
      *     instructionId?: string
      * } $transferInformation
      * @return CustomerDirectDebitTransferInformation


### PR DESCRIPTION
The façade method `CustomerDirectDebitFacade::addTransfer()` documents the `$transferInformation['debtorAdrLine']` field as `string`. However, the value is passed to `CustomerDirectDebitTransferInformation::setPostalAddress()` which can also handle an array of strings. I'd like to widen the type of the array shape to reflect that.