### PR TITLE
HotFix always include the Creditor Agent element

### DIFF
--- a/src/DomBuilder/BaseDomBuilder.php
+++ b/src/DomBuilder/BaseDomBuilder.php
@@ -152,6 +152,11 @@ abstract class BaseDomBuilder implements DomBuilderInterface
         $finInstitution = $this->createElement('FinInstnId');
 
         if ($bic === null) {
+            /*
+             * Use alternative identifier when BIC is not available
+             * Per ISO 20022: <Othr> can be used for alternative identification.
+             * We use this to circumvent some banks' strict BIC validation.
+             */
             $other = $this->createElement('Othr');
             $id = $this->createElement('Id', 'NOTPROVIDED');
             $other->appendChild($id);

--- a/src/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -196,17 +196,10 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         $CdtTrfTxInf->appendChild($amount);
 
         //Creditor Agent 2.77
-        if ($transactionInformation->getBic()) {
-            $creditorAgent = $this->createElement('CdtrAgt');
-            $financialInstitution = $this->createElement('FinInstnId');
-            if ($this->messageFormat->isCreditTransfer() && $this->messageFormat->getVariant() == '1' && $this->messageFormat->getVersion() >= 4) {
-                $financialInstitution->appendChild($this->createElement('BICFI', $transactionInformation->getBic()));
-            } else {
-                $financialInstitution->appendChild($this->createElement('BIC', $transactionInformation->getBic()));
-            }
-            $creditorAgent->appendChild($financialInstitution);
-            $CdtTrfTxInf->appendChild($creditorAgent);
-        }
+        $creditorAgent = $this->createElement('CdtrAgt');
+        $creditorAgent->appendChild($this->getFinancialInstitutionElement($transactionInformation->getBic()));
+        $CdtTrfTxInf->appendChild($creditorAgent);
+
 
         // Creditor 2.79
         $creditor = $this->createElement('Cdtr');

--- a/tests/Unit/TransferFile/Facade/CustomerCreditFacadeTest.php
+++ b/tests/Unit/TransferFile/Facade/CustomerCreditFacadeTest.php
@@ -115,8 +115,7 @@ class CustomerCreditFacadeTest extends TestCase
             'pain.001.001.08' => ['pain.001.001.08'],
             'pain.001.001.09' => ['pain.001.001.09'],
             'pain.001.001.10' => ['pain.001.001.10'],
-            'pain.001.001.11' => ['pain.001.001.12'],
-            'pain.001.003.03' => ['pain.001.003.03']
+            'pain.001.001.11' => ['pain.001.001.12']
         ];
     }
 }


### PR DESCRIPTION
# Changelog

## Changed
- Always include the `CdtrAgt` element in Customer Credit Transfers. Provide a default when there is no BIC.

# Notes
This fixes #215 
The ISO 20022 states that the `CdtrAgt` element could be omitted. However some banks are more strict with BIC validation. We use this feature to circumvent that problem.

Per ISO 20022: <Othr> can be used for alternative identification. We set that to 'NOTPROVIDED' and the result XML looks like:

```
<CdtrAgt>
  <FinInstnId>
    <Othr>
      <Id>NOTPROVIDED</Id>
    </Othr>
  </FinInstnId>
</CdtrAgt>
```