### PR TITLE
Make the UETR element NULL by default.

### DIFF
--- a/src/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -156,7 +156,7 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
             $PmtId->appendChild($this->createElement('InstrId', $transactionInformation->getInstructionId()));
         }
         $PmtId->appendChild($this->createElement('EndToEndId', $transactionInformation->getEndToEndIdentification()));
-        if ($this->messageFormat->isCreditTransfer() && $this->messageFormat->getVariant() == 1 && $this->messageFormat->getVersion() >= 9) {
+        if ($transactionInformation->getUUID() && $this->messageFormat->isCreditTransfer() && $this->messageFormat->getVariant() == 1 && $this->messageFormat->getVersion() >= 9) {
             $PmtId->appendChild($this->createElement('UETR', $transactionInformation->getUUID()));
         }
         $CdtTrfTxInf->appendChild($PmtId);

--- a/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -150,7 +150,7 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
         $paymentId->appendChild(
             $this->createElement('EndToEndId', $transactionInformation->getEndToEndIdentification())
         );
-        if ($this->messageFormat->isDirectDebit() && $this->messageFormat->getVariant() == 1 && $this->messageFormat->getVersion() >= 8) {
+        if ($transactionInformation->getUUID() && $this->messageFormat->isDirectDebit() && $this->messageFormat->getVariant() == 1 && $this->messageFormat->getVersion() >= 8) {
             $paymentId->appendChild($this->createElement('UETR', $transactionInformation->getUUID()));
         }
 

--- a/src/TransferInformation/BaseTransferInformation.php
+++ b/src/TransferInformation/BaseTransferInformation.php
@@ -81,7 +81,7 @@ class BaseTransferInformation implements TransferInformationInterface
     protected $EndToEndIdentification;
 
     /**
-     * @var string $UUID
+     * @var ?string $UUID
      */
     protected $UUID;
 
@@ -193,7 +193,6 @@ class BaseTransferInformation implements TransferInformationInterface
         $this->iban = $iban;
         $this->name = Sanitizer::sanitize($name);
         $this->setEndToEndIdentification($identification);
-        $this->setUUID(Uuid::uuid4()->toString());
     }
 
     public function accept(DomBuilderInterface $domBuilder): void
@@ -226,12 +225,12 @@ class BaseTransferInformation implements TransferInformationInterface
         return $this->EndToEndIdentification;
     }
 
-    public function setUUID(string $UUID): void
+    public function setUUID(?string $UUID): void
     {
         $this->UUID = $UUID;
     }
 
-    public function getUUID(): string
+    public function getUUID(): ?string
     {
         return $this->UUID;
     }

--- a/src/TransferInformation/TransferInformationInterface.php
+++ b/src/TransferInformation/TransferInformationInterface.php
@@ -32,7 +32,7 @@ interface TransferInformationInterface
 
     public function getEndToEndIdentification(): string;
 
-    public function getUUID(): string;
+    public function getUUID(): ?string;
 
     public function getInstructionId(): ?string;
 

--- a/tests/Unit/TransferInformation/CustomerCreditTransferInformationTest.php
+++ b/tests/Unit/TransferInformation/CustomerCreditTransferInformationTest.php
@@ -17,11 +17,10 @@ class CustomerCreditTransferInformationTest extends TestCase
         $this->assertEquals('Their Corp', $information->getEndToEndIdentification());
     }
 
-    public function testHasUniqueIdentifier(): void
+    public function testUniqueIdentifierNullByDefault(): void
     {
         $information = new CustomerCreditTransferInformation('100', 'DE12500105170648489890', 'Their Corp');
-        $this->assertNotEmpty($information->getUUID());
-        $this->assertTrue(Uuid::isValid($information->getUUID()));
+        $this->assertNull($information->getUUID());
     }
 
     public function testCustomUniqueIdentifier(): void

--- a/tests/Unit/TransferInformation/CustomerDirectDebitTransferInformationTest.php
+++ b/tests/Unit/TransferInformation/CustomerDirectDebitTransferInformationTest.php
@@ -37,11 +37,10 @@ class CustomerDirectDebitTransferInformationTest extends TestCase
         $this->assertEquals('Their Corp', $information->getEndToEndIdentification());
     }
 
-    public function testHasUniqueIdentifier(): void
+    public function testUniqueIdentifierNullByDefault(): void
     {
         $information = new CustomerDirectDebitTransferInformation(100, 'DE12500105170648489890', 'Their Corp', 'MyEndToEndId');
-        $this->assertNotEmpty($information->getUUID());
-        $this->assertTrue(Uuid::isValid($information->getUUID()));
+        $this->assertNull($information->getUUID());
     }
 
     public function testCustomUniqueIdentifier(): void


### PR DESCRIPTION
# Changelog

## Changed
- UETR (Unique End-to-End Transaction Reference) element to be null by default instead of automatically generating a UUID. The UETR element will now only be included in the generated XML when explicitly set by the user.

Key changes:

    Modified the getUUID() method to return a nullable string instead of a required string
    Removed automatic UUID generation from the constructor
    Updated conditional logic to check for UUID presence before adding UETR elements
