### PR TITLE
Expand unit-test coverage to 568 tests

### DIFF
--- a/tests/Unit/DomBuilder/CustomerCreditTransferDomBuilderTest.php
+++ b/tests/Unit/DomBuilder/CustomerCreditTransferDomBuilderTest.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\DomBuilder;
+
+use Digitick\Sepa\DomBuilder\CustomerCreditTransferDomBuilder;
+use Digitick\Sepa\GroupHeader;
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferFile\CustomerCreditTransferFile;
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
+use Digitick\Sepa\Util\MessageFormat;
+use PHPUnit\Framework\TestCase;
+
+class CustomerCreditTransferDomBuilderTest extends TestCase
+{
+    /**
+     * @dataProvider painProvider
+     */
+    public function testSchemaValidationAcrossPainVersions(string $painFormat): void
+    {
+        $builder = $this->buildBasic($painFormat);
+
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($builder->asXml());
+
+        $this->assertTrue($doc->schemaValidate(XSD_DIR . $painFormat . '.xsd'));
+    }
+
+    /**
+     * @dataProvider painProviderV9Plus
+     */
+    public function testWithAddress(string $painFormat): void
+    {
+        $messageFormat = new MessageFormat($painFormat);
+
+        $builder = new CustomerCreditTransferDomBuilder($painFormat);
+
+        $groupHeader = new GroupHeader('TEST_MSG', 'Test Company Inc.');
+        $groupHeader->setInitiatingPartyId('DE67ZZZ00000123456');
+
+        $payment = new PaymentInformation('P1', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Test Company Inc.');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerCreditTransferInformation(1000, 'DE40500105174181777145', 'Max Musterman');
+        $transfer->setCountry('DE');
+        $transfer->setPostCode('60431');
+        $transfer->setTownName('Frankfurt am Main');
+        $transfer->setStreetName('Wilhelm-Epstein-Str.');
+        $transfer->setBuildingNumber('14');
+        $transfer->setFloorNumber('12');
+
+        $builder->visitTransferFile($transferFile);
+        $builder->visitGroupHeader($groupHeader);
+        $builder->visitPaymentInformation($payment);
+        $builder->visitTransferInformation($transfer);
+
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($builder->asXml());
+
+        $this->assertTrue($doc->schemaValidate(XSD_DIR . $painFormat . '.xsd'));
+
+        $xpath = $this->xpath($doc, $painFormat);
+        $postalAddressNode = $xpath->evaluate('/ns:Document/ns:CstmrCdtTrfInitn/ns:PmtInf/ns:CdtTrfTxInf/ns:Cdtr/ns:PstlAdr')->item(0);
+
+        $this->assertNotNull($postalAddressNode);
+        $this->assertSame('DE', $xpath->evaluate('./ns:Ctry', $postalAddressNode)->item(0)->textContent);
+        $this->assertSame('60431', $xpath->evaluate('./ns:PstCd', $postalAddressNode)->item(0)->textContent);
+        $this->assertSame('Frankfurt am Main', $xpath->evaluate('./ns:TwnNm', $postalAddressNode)->item(0)->textContent);
+        $this->assertSame('Wilhelm-Epstein-Str.', $xpath->evaluate('./ns:StrtNm', $postalAddressNode)->item(0)->textContent);
+        $this->assertSame('14', $xpath->evaluate('./ns:BldgNb', $postalAddressNode)->item(0)->textContent);
+
+        // Flr only valid for variant 1, version >= 9.
+        if ($messageFormat->getVariant() === 1 && $messageFormat->getVersion() >= 9) {
+            $this->assertSame('12', $xpath->evaluate('./ns:Flr', $postalAddressNode)->item(0)->textContent);
+        } else {
+            $this->assertSame(0, $xpath->query('./ns:Flr', $postalAddressNode)->length);
+        }
+    }
+
+    public function testReqdExctnDtIsStructuredForVariant1V8Plus(): void
+    {
+        // Variant 1, version >= 8: ReqdExctnDt must wrap the date in <Dt>.
+        $builder = $this->buildBasic('pain.001.001.09');
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($builder->asXml());
+
+        $xpath = $this->xpath($doc, 'pain.001.001.09');
+
+        $this->assertSame(1, $xpath->query('//ns:PmtInf/ns:ReqdExctnDt/ns:Dt')->length);
+    }
+
+    public function testReqdExctnDtIsFlatForOlderVariant1Versions(): void
+    {
+        // Before version 8: ReqdExctnDt carries the date directly.
+        $builder = $this->buildBasic('pain.001.001.03');
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($builder->asXml());
+
+        $xpath = $this->xpath($doc, 'pain.001.001.03');
+
+        $this->assertSame(0, $xpath->query('//ns:PmtInf/ns:ReqdExctnDt/ns:Dt')->length);
+        $this->assertNotEmpty($xpath->evaluate('string(//ns:PmtInf/ns:ReqdExctnDt)'));
+    }
+
+    public function testOrgIdIsReplacedWhenInitiatingPartyIdSet(): void
+    {
+        $builder = new CustomerCreditTransferDomBuilder('pain.001.001.09');
+
+        $groupHeader = new GroupHeader('MSG', 'Initiator');
+        $groupHeader->setInitiatingPartyId('DE67ZZZ00000123456');
+        $groupHeader->setInitiatingPartyIdentificationScheme('BANK');
+
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = $this->newValidPayment();
+        $transferFile->addPaymentInformation($payment);
+        $payment->addTransfer(new CustomerCreditTransferInformation(100, 'DE12345', 'Bob'));
+
+        $transferFile->accept($builder);
+
+        $xpath = $this->xpath($this->asDoc($builder), 'pain.001.001.09');
+
+        // After replacement the InitgPty/Id must contain OrgId/Othr/Id rather
+        // than the default flat Id text node.
+        $this->assertSame(
+            'DE67ZZZ00000123456',
+            $xpath->evaluate('string(//ns:GrpHdr/ns:InitgPty/ns:Id/ns:OrgId/ns:Othr/ns:Id)')
+        );
+        $this->assertSame(
+            'BANK',
+            $xpath->evaluate('string(//ns:GrpHdr/ns:InitgPty/ns:Id/ns:OrgId/ns:Othr/ns:SchmeNm/ns:Cd)')
+        );
+    }
+
+    public function testCategoryPurposeCodeIsRendered(): void
+    {
+        $builder = new CustomerCreditTransferDomBuilder('pain.001.001.09');
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = $this->newValidPayment();
+        $payment->setCategoryPurposeCode('SALA');
+        $transferFile->addPaymentInformation($payment);
+        $payment->addTransfer(new CustomerCreditTransferInformation(100, 'DE12345', 'Bob'));
+
+        $transferFile->accept($builder);
+
+        $xpath = $this->xpath($this->asDoc($builder), 'pain.001.001.09');
+
+        $this->assertSame('SALA', $xpath->evaluate('string(//ns:PmtInf/ns:PmtTpInf/ns:CtgyPurp/ns:Cd)'));
+    }
+
+    public function testLocalInstrumentCodeRendered(): void
+    {
+        $builder = new CustomerCreditTransferDomBuilder('pain.001.001.09');
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = $this->newValidPayment();
+        $payment->setLocalInstrumentCode('CORE');
+        $transferFile->addPaymentInformation($payment);
+        $payment->addTransfer(new CustomerCreditTransferInformation(100, 'DE12345', 'Bob'));
+
+        $transferFile->accept($builder);
+
+        $xpath = $this->xpath($this->asDoc($builder), 'pain.001.001.09');
+
+        $this->assertSame('CORE', $xpath->evaluate('string(//ns:PmtInf/ns:PmtTpInf/ns:LclInstrm/ns:Cd)'));
+        $this->assertSame(0, $xpath->query('//ns:PmtInf/ns:PmtTpInf/ns:LclInstrm/ns:Prtry')->length);
+    }
+
+    public function testLocalInstrumentProprietaryRenderedWhenCodeAbsent(): void
+    {
+        $builder = new CustomerCreditTransferDomBuilder('pain.001.001.09');
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = $this->newValidPayment();
+        $payment->setLocalInstrumentProprietary('LOCAL-STUFF');
+        $transferFile->addPaymentInformation($payment);
+        $payment->addTransfer(new CustomerCreditTransferInformation(100, 'DE12345', 'Bob'));
+
+        $transferFile->accept($builder);
+
+        $xpath = $this->xpath($this->asDoc($builder), 'pain.001.001.09');
+
+        $this->assertSame('LOCAL-STUFF', $xpath->evaluate('string(//ns:PmtInf/ns:PmtTpInf/ns:LclInstrm/ns:Prtry)'));
+        $this->assertSame(0, $xpath->query('//ns:PmtInf/ns:PmtTpInf/ns:LclInstrm/ns:Cd')->length);
+    }
+
+    public function testInstructionPriorityIsRenderedForVariant1(): void
+    {
+        $builder = new CustomerCreditTransferDomBuilder('pain.001.001.09');
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = $this->newValidPayment();
+        $payment->setInstructionPriority('HIGH');
+        $transferFile->addPaymentInformation($payment);
+        $payment->addTransfer(new CustomerCreditTransferInformation(100, 'DE12345', 'Bob'));
+
+        $transferFile->accept($builder);
+
+        $xpath = $this->xpath($this->asDoc($builder), 'pain.001.001.09');
+
+        $this->assertSame('HIGH', $xpath->evaluate('string(//ns:PmtInf/ns:PmtTpInf/ns:InstrPrty)'));
+    }
+
+    /**
+     * @dataProvider stpVariantProvider
+     */
+    public function testVariant2And3SuppressStructuredAddressFields(string $painFormat): void
+    {
+        // pain.001.002.03 (STP) and pain.001.003.03 (EU STP) only allow
+        // Ctry and AdrLine inside PstlAdr — the structured fields must not
+        // be emitted even if set on the TransferInformation, otherwise the
+        // XSD rejects the document.
+        $builder = new CustomerCreditTransferDomBuilder($painFormat);
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = $this->newValidPayment();
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerCreditTransferInformation(100, 'DE40500105174181777145', 'Bob');
+        $transfer->setBic('DEUTDEFF');
+        $transfer->setCountry('DE');
+        $transfer->setPostalAddress('Some Street 123, 12345 Berlin');
+        // Deliberately populate structured fields — builder must suppress them
+        $transfer->setStreetName('Wilhelm-Epstein-Str.');
+        $transfer->setBuildingNumber('14');
+        $transfer->setPostCode('60431');
+        $transfer->setTownName('Frankfurt');
+        $transfer->setFloorNumber('2');
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        $doc = $this->asDoc($builder);
+        $this->assertTrue(
+            $doc->schemaValidate(XSD_DIR . $painFormat . '.xsd'),
+            'Emitted XML must validate against the variant 2/3 schema'
+        );
+
+        $xpath = $this->xpath($doc, $painFormat);
+        $postalAddressNode = $xpath->evaluate('//ns:CdtTrfTxInf/ns:Cdtr/ns:PstlAdr')->item(0);
+        $this->assertNotNull($postalAddressNode);
+
+        // Allowed: Ctry + AdrLine
+        $this->assertSame('DE', $xpath->evaluate('string(./ns:Ctry)', $postalAddressNode));
+        $this->assertSame(
+            'Some Street 123, 12345 Berlin',
+            $xpath->evaluate('string(./ns:AdrLine)', $postalAddressNode)
+        );
+
+        // Suppressed structured fields
+        $this->assertSame(0, $xpath->query('./ns:StrtNm', $postalAddressNode)->length);
+        $this->assertSame(0, $xpath->query('./ns:BldgNb', $postalAddressNode)->length);
+        $this->assertSame(0, $xpath->query('./ns:PstCd', $postalAddressNode)->length);
+        $this->assertSame(0, $xpath->query('./ns:TwnNm', $postalAddressNode)->length);
+        $this->assertSame(0, $xpath->query('./ns:Flr', $postalAddressNode)->length);
+    }
+
+    public static function stpVariantProvider(): iterable
+    {
+        return [
+            'pain.001.002.03 (STP)'    => ['pain.001.002.03'],
+            'pain.001.003.03 (EU STP)' => ['pain.001.003.03'],
+        ];
+    }
+
+    public function testInstructionPriorityIsSuppressedForNonVariant1(): void
+    {
+        // Variant 2 (pain.001.002.03) does not carry InstrPrty under PmtTpInf.
+        $builder = new CustomerCreditTransferDomBuilder('pain.001.002.03');
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = $this->newValidPayment();
+        $payment->setInstructionPriority('HIGH');
+        $transferFile->addPaymentInformation($payment);
+        $payment->addTransfer(new CustomerCreditTransferInformation(100, 'DE12345', 'Bob'));
+
+        $transferFile->accept($builder);
+
+        $xpath = $this->xpath($this->asDoc($builder), 'pain.001.002.03');
+
+        $this->assertSame(0, $xpath->query('//ns:PmtInf/ns:PmtTpInf/ns:InstrPrty')->length);
+    }
+
+    public static function painProvider(): iterable
+    {
+        return [
+            'pain.001.001.03' => ['pain.001.001.03'],
+            'pain.001.001.04' => ['pain.001.001.04'],
+            'pain.001.001.05' => ['pain.001.001.05'],
+            'pain.001.001.06' => ['pain.001.001.06'],
+            'pain.001.001.07' => ['pain.001.001.07'],
+            'pain.001.001.08' => ['pain.001.001.08'],
+            'pain.001.001.09' => ['pain.001.001.09'],
+            'pain.001.001.10' => ['pain.001.001.10'],
+            'pain.001.001.12' => ['pain.001.001.12'],
+        ];
+    }
+
+    public static function painProviderV9Plus(): iterable
+    {
+        // Versions where PstlAdr with structured fields is meaningful.
+        return [
+            'pain.001.001.03' => ['pain.001.001.03'],
+            'pain.001.001.04' => ['pain.001.001.04'],
+            'pain.001.001.05' => ['pain.001.001.05'],
+            'pain.001.001.06' => ['pain.001.001.06'],
+            'pain.001.001.07' => ['pain.001.001.07'],
+            'pain.001.001.08' => ['pain.001.001.08'],
+            'pain.001.001.09' => ['pain.001.001.09'],
+            'pain.001.001.10' => ['pain.001.001.10'],
+            'pain.001.001.12' => ['pain.001.001.12'],
+        ];
+    }
+
+    private function buildBasic(string $painFormat): CustomerCreditTransferDomBuilder
+    {
+        $builder = new CustomerCreditTransferDomBuilder($painFormat);
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = $this->newValidPayment();
+        $transferFile->addPaymentInformation($payment);
+        $transfer = new CustomerCreditTransferInformation(100, 'DE12345', 'Bob');
+        $transfer->setBic('DEUTDEFF');
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        return $builder;
+    }
+
+    private function newValidPayment(): PaymentInformation
+    {
+        return new PaymentInformation('P1', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Origin');
+    }
+
+    private function asDoc(CustomerCreditTransferDomBuilder $builder): \DOMDocument
+    {
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($builder->asXml());
+        return $doc;
+    }
+
+    private function xpath(\DOMDocument $doc, string $painFormat): \DOMXPath
+    {
+        $xp = new \DOMXPath($doc);
+        $xp->registerNamespace('ns', sprintf('urn:iso:std:iso:20022:tech:xsd:%s', $painFormat));
+        return $xp;
+    }
+}

--- a/tests/Unit/DomBuilder/CustomerDirectDebitTransferDomBuilderTest.php
+++ b/tests/Unit/DomBuilder/CustomerDirectDebitTransferDomBuilderTest.php
@@ -132,4 +132,197 @@ class CustomerDirectDebitTransferDomBuilderTest extends TestCase
 
         $this->assertSame('INGDDEFFXXX', $xpath->evaluate('./ns:BICFI', $finInstnIdNode)->item(0)->textContent);
     }
+
+    public function testAmendedDebtorAccountEmitsSmndaOrgnlDbtrAcct(): void
+    {
+        $xpath = $this->renderWithAmendments(function ($transfer) {
+            $transfer->setAmendedDebtorAccount(true);
+        });
+
+        $this->assertSame(
+            'true',
+            $xpath->evaluate('string(//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInd)')
+        );
+        $this->assertSame(
+            'SMNDA',
+            $xpath->evaluate(
+                'string(//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInfDtls/ns:OrgnlDbtrAcct/ns:Id/ns:Othr/ns:Id)'
+            )
+        );
+        $this->assertSame(
+            0,
+            $xpath->query('//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInfDtls/ns:OrgnlMndtId')->length,
+            'OrgnlMndtId must be absent when only the debtor account is amended'
+        );
+    }
+
+    public function testOriginalMandateIdEmitsOrgnlMndtId(): void
+    {
+        $xpath = $this->renderWithAmendments(function ($transfer) {
+            $transfer->setOriginalMandateId('OLD-MANDATE-42');
+        });
+
+        $this->assertSame(
+            'true',
+            $xpath->evaluate('string(//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInd)')
+        );
+        $this->assertSame(
+            'OLD-MANDATE-42',
+            $xpath->evaluate('string(//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInfDtls/ns:OrgnlMndtId)')
+        );
+        $this->assertSame(
+            0,
+            $xpath->query('//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInfDtls/ns:OrgnlDbtrAcct')->length,
+            'OrgnlDbtrAcct must be absent when only the mandate id is amended'
+        );
+    }
+
+    public function testOriginalDebtorIbanAlsoTriggersSmndaOrgnlDbtrAcct(): void
+    {
+        // The builder emits the SMNDA sentinel when either amendedDebtorAccount
+        // or originalDebtorIban is set — verify the latter path.
+        $xpath = $this->renderWithAmendments(function ($transfer) {
+            $transfer->setOriginalDebtorIban('DE11520513735120710131');
+        });
+
+        $this->assertSame(
+            'SMNDA',
+            $xpath->evaluate(
+                'string(//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInfDtls/ns:OrgnlDbtrAcct/ns:Id/ns:Othr/ns:Id)'
+            )
+        );
+    }
+
+    public function testBothAmendmentsEmitBothNodes(): void
+    {
+        $xpath = $this->renderWithAmendments(function ($transfer) {
+            $transfer->setAmendedDebtorAccount(true);
+            $transfer->setOriginalMandateId('OLD-MANDATE-42');
+        });
+
+        $this->assertSame(
+            'SMNDA',
+            $xpath->evaluate(
+                'string(//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInfDtls/ns:OrgnlDbtrAcct/ns:Id/ns:Othr/ns:Id)'
+            )
+        );
+        $this->assertSame(
+            'OLD-MANDATE-42',
+            $xpath->evaluate('string(//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInfDtls/ns:OrgnlMndtId)')
+        );
+    }
+
+    /**
+     * @dataProvider sddStpVariantProvider
+     */
+    public function testVariant2And3SuppressStructuredAddressFields(string $painFormat): void
+    {
+        // pain.008.002.02 and pain.008.003.02 only allow Ctry and AdrLine
+        // inside PstlAdr — structured fields must not be emitted.
+        $builder = new \Digitick\Sepa\DomBuilder\CustomerDirectDebitTransferDomBuilder($painFormat);
+
+        $groupHeader = new \Digitick\Sepa\GroupHeader('MSG', 'Init');
+        $transferFile = new \Digitick\Sepa\TransferFile\CustomerDirectDebitTransferFile($groupHeader);
+        $payment = new \Digitick\Sepa\PaymentInformation('P1', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Origin');
+        $payment->setSequenceType(\Digitick\Sepa\PaymentInformation::S_ONEOFF);
+        $payment->setCreditorId('DE67ZZZ00000123456');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new \Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation(
+            100, 'DE40500105174181777145', 'Bob'
+        );
+        $transfer->setBic('DEUTDEFF');
+        $transfer->setMandateId('M1');
+        $transfer->setMandateSignDate(new \DateTimeImmutable('2022-05-15'));
+        $transfer->setCountry('DE');
+        $transfer->setPostalAddress('Some Street 123, 12345 Berlin');
+        // These must be suppressed by the builder for variants 2 and 3
+        $transfer->setStreetName('Wilhelm-Epstein-Str.');
+        $transfer->setBuildingNumber('14');
+        $transfer->setPostCode('60431');
+        $transfer->setTownName('Frankfurt');
+        $transfer->setFloorNumber('2');
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($builder->asXml());
+        $this->assertTrue(
+            $doc->schemaValidate(XSD_DIR . $painFormat . '.xsd'),
+            'Emitted XML must validate against the variant 2/3 schema'
+        );
+
+        $xpath = new \DOMXPath($doc);
+        $xpath->registerNamespace('ns', sprintf('urn:iso:std:iso:20022:tech:xsd:%s', $painFormat));
+
+        $postalAddressNode = $xpath->evaluate('//ns:DrctDbtTxInf/ns:Dbtr/ns:PstlAdr')->item(0);
+        $this->assertNotNull($postalAddressNode);
+
+        $this->assertSame('DE', $xpath->evaluate('string(./ns:Ctry)', $postalAddressNode));
+        $this->assertSame(
+            'Some Street 123, 12345 Berlin',
+            $xpath->evaluate('string(./ns:AdrLine)', $postalAddressNode)
+        );
+        $this->assertSame(0, $xpath->query('./ns:StrtNm', $postalAddressNode)->length);
+        $this->assertSame(0, $xpath->query('./ns:BldgNb', $postalAddressNode)->length);
+        $this->assertSame(0, $xpath->query('./ns:PstCd', $postalAddressNode)->length);
+        $this->assertSame(0, $xpath->query('./ns:TwnNm', $postalAddressNode)->length);
+        $this->assertSame(0, $xpath->query('./ns:Flr', $postalAddressNode)->length);
+    }
+
+    public static function sddStpVariantProvider(): iterable
+    {
+        return [
+            'pain.008.002.02 (STP)'    => ['pain.008.002.02'],
+            'pain.008.003.02 (EU STP)' => ['pain.008.003.02'],
+        ];
+    }
+
+    public function testNoAmendmentsSuppressesAmdmntInd(): void
+    {
+        $xpath = $this->renderWithAmendments(function ($transfer) {
+            // deliberately set no amendments
+        });
+
+        $this->assertSame(
+            0,
+            $xpath->query('//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInd')->length
+        );
+        $this->assertSame(
+            0,
+            $xpath->query('//ns:DrctDbtTx/ns:MndtRltdInf/ns:AmdmntInfDtls')->length
+        );
+    }
+
+    private function renderWithAmendments(callable $configureTransfer): \DOMXPath
+    {
+        $painFormat = 'pain.008.001.02';
+        $builder = new \Digitick\Sepa\DomBuilder\CustomerDirectDebitTransferDomBuilder($painFormat);
+
+        $groupHeader = new \Digitick\Sepa\GroupHeader('MSG', 'Init');
+        $transferFile = new \Digitick\Sepa\TransferFile\CustomerDirectDebitTransferFile($groupHeader);
+        $payment = new \Digitick\Sepa\PaymentInformation('P1', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Origin');
+        $payment->setSequenceType(\Digitick\Sepa\PaymentInformation::S_ONEOFF);
+        $payment->setCreditorId('DE67ZZZ00000123456');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new \Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation(
+            100, 'DE40500105174181777145', 'Bob'
+        );
+        $transfer->setBic('DEUTDEFF');
+        $transfer->setMandateId('M1');
+        $transfer->setMandateSignDate(new \DateTimeImmutable('2022-05-15'));
+        $configureTransfer($transfer);
+
+        $payment->addTransfer($transfer);
+        $transferFile->accept($builder);
+
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($builder->asXml());
+        $xpath = new \DOMXPath($doc);
+        $xpath->registerNamespace('ns', sprintf('urn:iso:std:iso:20022:tech:xsd:%s', $painFormat));
+
+        return $xpath;
+    }
 }

--- a/tests/Unit/DomBuilder/DomBuilderFactoryTest.php
+++ b/tests/Unit/DomBuilder/DomBuilderFactoryTest.php
@@ -62,4 +62,14 @@ class DomBuilderFactoryTest extends TestCase
         $domBuilder = DomBuilderFactory::createDomBuilder($sepaFile);
         $this->assertInstanceOf(\Digitick\Sepa\DomBuilder\CustomerDirectDebitTransferDomBuilder::class, $domBuilder);
     }
+
+    public function testCreateThrowsForUnknownTransferFileImplementation(): void
+    {
+        $unknown = new class (new GroupHeader('MSG', 'Init')) extends \Digitick\Sepa\TransferFile\BaseTransferFile {
+        };
+
+        $this->expectException(\Digitick\Sepa\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not a valid Transferfile');
+        DomBuilderFactory::createDomBuilder($unknown);
+    }
 }

--- a/tests/Unit/DomBuilder/FinancialInstitutionElementTest.php
+++ b/tests/Unit/DomBuilder/FinancialInstitutionElementTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\DomBuilder;
+
+use Digitick\Sepa\DomBuilder\CustomerCreditTransferDomBuilder;
+use Digitick\Sepa\DomBuilder\CustomerDirectDebitTransferDomBuilder;
+use Digitick\Sepa\GroupHeader;
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferFile\CustomerCreditTransferFile;
+use Digitick\Sepa\TransferFile\CustomerDirectDebitTransferFile;
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
+use Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises the three branches of BaseDomBuilder::getFinancialInstitutionElement:
+ *  - legacy <BIC>
+ *  - <BICFI> (SCT variant 1 v>=4, SDD variant 1 v>=3)
+ *  - <Othr><Id>NOTPROVIDED</Id></Othr> fallback when BIC is null
+ *
+ * Read it together with IMPROVEMENTS.md #4 and open issue #233: when the
+ * NOTPROVIDED strategy becomes pluggable these tests stake out the current
+ * behaviour.
+ */
+class FinancialInstitutionElementTest extends TestCase
+{
+    /**
+     * @dataProvider sctLegacyBicProvider
+     */
+    public function testSCTEmitsLegacyBicForVariant1BeforeV4(string $painFormat): void
+    {
+        $xpath = $this->sctXpath($painFormat, 'DEUTDEFF');
+
+        $this->assertSame(1, $xpath->query('//ns:CdtTrfTxInf/ns:CdtrAgt/ns:FinInstnId/ns:BIC')->length);
+        $this->assertSame(0, $xpath->query('//ns:CdtTrfTxInf/ns:CdtrAgt/ns:FinInstnId/ns:BICFI')->length);
+        $this->assertSame(
+            'DEUTDEFF',
+            $xpath->evaluate('string(//ns:CdtTrfTxInf/ns:CdtrAgt/ns:FinInstnId/ns:BIC)')
+        );
+    }
+
+    /**
+     * @dataProvider sctBicfiProvider
+     */
+    public function testSCTEmitsBicfiForVariant1V4Plus(string $painFormat): void
+    {
+        $xpath = $this->sctXpath($painFormat, 'DEUTDEFF');
+
+        $this->assertSame(1, $xpath->query('//ns:CdtTrfTxInf/ns:CdtrAgt/ns:FinInstnId/ns:BICFI')->length);
+        $this->assertSame(0, $xpath->query('//ns:CdtTrfTxInf/ns:CdtrAgt/ns:FinInstnId/ns:BIC')->length);
+        $this->assertSame(
+            'DEUTDEFF',
+            $xpath->evaluate('string(//ns:CdtTrfTxInf/ns:CdtrAgt/ns:FinInstnId/ns:BICFI)')
+        );
+    }
+
+    /**
+     * @dataProvider sctLegacyBicProvider
+     * @dataProvider sctBicfiProvider
+     */
+    public function testSCTFallsBackToNotProvidedWhenBicIsNull(string $painFormat): void
+    {
+        $xpath = $this->sctXpath($painFormat, null);
+
+        $this->assertSame(
+            'NOTPROVIDED',
+            $xpath->evaluate('string(//ns:CdtTrfTxInf/ns:CdtrAgt/ns:FinInstnId/ns:Othr/ns:Id)'),
+            'NOTPROVIDED fallback expected for ' . $painFormat
+        );
+        $this->assertSame(0, $xpath->query('//ns:CdtTrfTxInf/ns:CdtrAgt/ns:FinInstnId/ns:BIC')->length);
+        $this->assertSame(0, $xpath->query('//ns:CdtTrfTxInf/ns:CdtrAgt/ns:FinInstnId/ns:BICFI')->length);
+    }
+
+    /**
+     * @dataProvider sddLegacyBicProvider
+     */
+    public function testSDDEmitsLegacyBicForVariant1BeforeV3(string $painFormat): void
+    {
+        $xpath = $this->sddXpath($painFormat, 'DEUTDEFF');
+
+        $this->assertSame(1, $xpath->query('//ns:DrctDbtTxInf/ns:DbtrAgt/ns:FinInstnId/ns:BIC')->length);
+        $this->assertSame(0, $xpath->query('//ns:DrctDbtTxInf/ns:DbtrAgt/ns:FinInstnId/ns:BICFI')->length);
+    }
+
+    /**
+     * @dataProvider sddBicfiProvider
+     */
+    public function testSDDEmitsBicfiForVariant1V3Plus(string $painFormat): void
+    {
+        $xpath = $this->sddXpath($painFormat, 'DEUTDEFF');
+
+        $this->assertSame(1, $xpath->query('//ns:DrctDbtTxInf/ns:DbtrAgt/ns:FinInstnId/ns:BICFI')->length);
+        $this->assertSame(0, $xpath->query('//ns:DrctDbtTxInf/ns:DbtrAgt/ns:FinInstnId/ns:BIC')->length);
+    }
+
+    /**
+     * @dataProvider sddBicfiProvider
+     */
+    public function testSDDFallsBackToNotProvidedWhenBicIsNull(string $painFormat): void
+    {
+        $xpath = $this->sddXpath($painFormat, null);
+
+        $this->assertSame(
+            'NOTPROVIDED',
+            $xpath->evaluate('string(//ns:DrctDbtTxInf/ns:DbtrAgt/ns:FinInstnId/ns:Othr/ns:Id)')
+        );
+    }
+
+    public static function sctLegacyBicProvider(): iterable
+    {
+        return [
+            'pain.001.001.03' => ['pain.001.001.03'],
+        ];
+    }
+
+    public static function sctBicfiProvider(): iterable
+    {
+        return [
+            'pain.001.001.09' => ['pain.001.001.09'],
+            'pain.001.001.10' => ['pain.001.001.10'],
+            'pain.001.001.12' => ['pain.001.001.12'],
+        ];
+    }
+
+    public static function sddLegacyBicProvider(): iterable
+    {
+        return [
+            'pain.008.001.02' => ['pain.008.001.02'],
+        ];
+    }
+
+    public static function sddBicfiProvider(): iterable
+    {
+        return [
+            'pain.008.001.09' => ['pain.008.001.09'],
+            'pain.008.001.10' => ['pain.008.001.10'],
+            'pain.008.001.11' => ['pain.008.001.11'],
+        ];
+    }
+
+    private function sctXpath(string $painFormat, ?string $transferBic): \DOMXPath
+    {
+        $builder = new CustomerCreditTransferDomBuilder($painFormat);
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = new PaymentInformation('P1', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Origin');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerCreditTransferInformation(100, 'DE40500105174181777145', 'Bob');
+        if ($transferBic !== null) {
+            $transfer->setBic($transferBic);
+        }
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        return $this->xpath($builder->asXml(), $painFormat);
+    }
+
+    private function sddXpath(string $painFormat, ?string $transferBic): \DOMXPath
+    {
+        $builder = new CustomerDirectDebitTransferDomBuilder($painFormat);
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerDirectDebitTransferFile($groupHeader);
+        $payment = new PaymentInformation('P1', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Origin');
+        $payment->setSequenceType(PaymentInformation::S_ONEOFF);
+        $payment->setCreditorId('DE67ZZZ00000123456');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerDirectDebitTransferInformation(100, 'DE40500105174181777145', 'Bob');
+        $transfer->setMandateId('M1');
+        $transfer->setMandateSignDate(new \DateTimeImmutable('2022-05-15'));
+        if ($transferBic !== null) {
+            $transfer->setBic($transferBic);
+        }
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        return $this->xpath($builder->asXml(), $painFormat);
+    }
+
+    private function xpath(string $xml, string $painFormat): \DOMXPath
+    {
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($xml);
+        $xpath = new \DOMXPath($doc);
+        $xpath->registerNamespace('ns', sprintf('urn:iso:std:iso:20022:tech:xsd:%s', $painFormat));
+        return $xpath;
+    }
+}

--- a/tests/Unit/DomBuilder/IntToCurrencyTest.php
+++ b/tests/Unit/DomBuilder/IntToCurrencyTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\DomBuilder;
+
+use Digitick\Sepa\DomBuilder\CustomerCreditTransferDomBuilder;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Isolated tests for BaseDomBuilder::intToCurrency (cents → string "xxx.yy").
+ *
+ * Context this guards: monetary formatting is regulated in SEPA — a flip from
+ * sprintf('%F', …) to '%f' would silently introduce a locale-dependent
+ * decimal separator (',' in many European locales) and produce schema-invalid
+ * XML in production. The functional tests cover the integer-money path
+ * end-to-end once per data set; this file locks the formatter behaviour down
+ * at the unit level.
+ */
+class IntToCurrencyTest extends TestCase
+{
+    /**
+     * @dataProvider amountProvider
+     */
+    public function testFormatting(int $cents, string $expected): void
+    {
+        $formatter = $this->formatter();
+
+        $this->assertSame($expected, $formatter->publicIntToCurrency($cents));
+    }
+
+    public static function amountProvider(): iterable
+    {
+        return [
+            'zero'            => [0, '0.00'],
+            'one cent'        => [1, '0.01'],
+            'ten cents'       => [10, '0.10'],
+            'ninety-nine'     => [99, '0.99'],
+            'one euro'        => [100, '1.00'],
+            'typical'         => [12345, '123.45'],
+            'thousand euros'  => [100000, '1000.00'],
+            'max SEPA amount' => [99999999999, '999999999.99'],
+        ];
+    }
+
+    /**
+     * @dataProvider localeProvider
+     */
+    public function testFormattingIsLocaleInsensitive(string $localeName, array $locales): void
+    {
+        $original = setlocale(LC_ALL, '0');
+        $applied = setlocale(LC_ALL, ...$locales);
+        if ($applied === false) {
+            $this->markTestSkipped(sprintf('%s locale unavailable on this system', $localeName));
+        }
+
+        try {
+            $formatter = $this->formatter();
+            $this->assertSame(
+                '123.45',
+                $formatter->publicIntToCurrency(12345),
+                "intToCurrency must produce '.' as the decimal separator regardless of locale"
+            );
+        } finally {
+            setlocale(LC_ALL, $original);
+        }
+    }
+
+    public static function localeProvider(): iterable
+    {
+        return [
+            'Spanish' => ['Spanish', ['es_ES.UTF-8', 'es_ES@UTF-8', 'spanish']],
+            'French'  => ['French',  ['fr_FR.UTF-8', 'fr_FR@UTF-8', 'french']],
+            'German'  => ['German',  ['de_DE.UTF-8', 'de_DE@UTF-8', 'german']],
+        ];
+    }
+
+    private function formatter(): object
+    {
+        return new class('pain.001.001.09') extends CustomerCreditTransferDomBuilder {
+            public function publicIntToCurrency(int $amount): string
+            {
+                return $this->intToCurrency($amount);
+            }
+        };
+    }
+}

--- a/tests/Unit/DomBuilder/StructuredRemittanceTest.php
+++ b/tests/Unit/DomBuilder/StructuredRemittanceTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\DomBuilder;
+
+use Digitick\Sepa\DomBuilder\CustomerCreditTransferDomBuilder;
+use Digitick\Sepa\DomBuilder\CustomerDirectDebitTransferDomBuilder;
+use Digitick\Sepa\GroupHeader;
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferFile\CustomerCreditTransferFile;
+use Digitick\Sepa\TransferFile\CustomerDirectDebitTransferFile;
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
+use Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Asserts the wire shape produced by BaseDomBuilder::getStructuredRemittanceElement
+ * (creditor-reference path). The SCT/SDD XSDs permit arbitrary free-text under
+ * RmtInf/Ustrd, so a regression in this path would slip past schema validation
+ * but get rejected downstream by bank validators.
+ *
+ * Shape asserted:
+ *   RmtInf
+ *     Strd
+ *       CdtrRefInf
+ *         Tp
+ *           CdOrPrtry
+ *             Cd = 'SCOR'
+ *           [Issr = creditorReferenceType]   (optional)
+ *         Ref = creditorReference
+ */
+class StructuredRemittanceTest extends TestCase
+{
+    private const SCT_PAIN = 'pain.001.001.09';
+    private const SDD_PAIN = 'pain.008.001.02';
+
+    public function testSCTEmitsScorStructuredRemittanceWithoutIssuer(): void
+    {
+        $xpath = $this->sctXpath(function (CustomerCreditTransferInformation $t) {
+            $t->setCreditorReference('RF81123453');
+        });
+
+        $this->assertSame(1, $xpath->query('//ns:CdtTrfTxInf/ns:RmtInf/ns:Strd/ns:CdtrRefInf')->length);
+        $this->assertSame(
+            'SCOR',
+            $xpath->evaluate('string(//ns:CdtTrfTxInf/ns:RmtInf/ns:Strd/ns:CdtrRefInf/ns:Tp/ns:CdOrPrtry/ns:Cd)')
+        );
+        $this->assertSame(
+            'RF81123453',
+            $xpath->evaluate('string(//ns:CdtTrfTxInf/ns:RmtInf/ns:Strd/ns:CdtrRefInf/ns:Ref)')
+        );
+        $this->assertSame(
+            0,
+            $xpath->query('//ns:CdtTrfTxInf/ns:RmtInf/ns:Strd/ns:CdtrRefInf/ns:Tp/ns:Issr')->length,
+            'Issr must be omitted when creditorReferenceType is not set'
+        );
+    }
+
+    public function testSCTEmitsScorStructuredRemittanceWithIssuer(): void
+    {
+        $xpath = $this->sctXpath(function (CustomerCreditTransferInformation $t) {
+            $t->setCreditorReference('RF81123453');
+            $t->setCreditorReferenceType('ISO-11649');
+        });
+
+        $this->assertSame(
+            'ISO-11649',
+            $xpath->evaluate('string(//ns:CdtTrfTxInf/ns:RmtInf/ns:Strd/ns:CdtrRefInf/ns:Tp/ns:Issr)')
+        );
+    }
+
+    public function testSCTUnstructuredRemittanceDoesNotEmitStrd(): void
+    {
+        $xpath = $this->sctXpath(function (CustomerCreditTransferInformation $t) {
+            $t->setRemittanceInformation('Invoice 42');
+        });
+
+        $this->assertSame(0, $xpath->query('//ns:CdtTrfTxInf/ns:RmtInf/ns:Strd')->length);
+        $this->assertSame(
+            'Invoice 42',
+            $xpath->evaluate('string(//ns:CdtTrfTxInf/ns:RmtInf/ns:Ustrd)')
+        );
+    }
+
+    public function testSCTCreditorReferenceTakesPrecedenceOverRemittanceInformation(): void
+    {
+        // The DomBuilder prefers the structured path when a creditorReference
+        // is set, even if remittanceInformation is also populated.
+        $xpath = $this->sctXpath(function (CustomerCreditTransferInformation $t) {
+            $t->setCreditorReference('RF81123453');
+            $t->setRemittanceInformation('Should be ignored');
+        });
+
+        $this->assertSame(1, $xpath->query('//ns:CdtTrfTxInf/ns:RmtInf/ns:Strd')->length);
+        $this->assertSame(0, $xpath->query('//ns:CdtTrfTxInf/ns:RmtInf/ns:Ustrd')->length);
+    }
+
+    public function testSDDEmitsScorStructuredRemittanceWithoutIssuer(): void
+    {
+        $xpath = $this->sddXpath(function (CustomerDirectDebitTransferInformation $t) {
+            $t->setCreditorReference('RF81123453');
+        });
+
+        $this->assertSame(
+            'SCOR',
+            $xpath->evaluate('string(//ns:DrctDbtTxInf/ns:RmtInf/ns:Strd/ns:CdtrRefInf/ns:Tp/ns:CdOrPrtry/ns:Cd)')
+        );
+        $this->assertSame(
+            'RF81123453',
+            $xpath->evaluate('string(//ns:DrctDbtTxInf/ns:RmtInf/ns:Strd/ns:CdtrRefInf/ns:Ref)')
+        );
+        $this->assertSame(
+            0,
+            $xpath->query('//ns:DrctDbtTxInf/ns:RmtInf/ns:Strd/ns:CdtrRefInf/ns:Tp/ns:Issr')->length
+        );
+    }
+
+    public function testSDDEmitsScorStructuredRemittanceWithIssuer(): void
+    {
+        $xpath = $this->sddXpath(function (CustomerDirectDebitTransferInformation $t) {
+            $t->setCreditorReference('RF81123453');
+            $t->setCreditorReferenceType('ISO-11649');
+        });
+
+        $this->assertSame(
+            'ISO-11649',
+            $xpath->evaluate('string(//ns:DrctDbtTxInf/ns:RmtInf/ns:Strd/ns:CdtrRefInf/ns:Tp/ns:Issr)')
+        );
+    }
+
+    public function testSDDUnstructuredRemittanceDoesNotEmitStrd(): void
+    {
+        $xpath = $this->sddXpath(function (CustomerDirectDebitTransferInformation $t) {
+            $t->setRemittanceInformation('Invoice 42');
+        });
+
+        $this->assertSame(0, $xpath->query('//ns:DrctDbtTxInf/ns:RmtInf/ns:Strd')->length);
+        $this->assertSame(
+            'Invoice 42',
+            $xpath->evaluate('string(//ns:DrctDbtTxInf/ns:RmtInf/ns:Ustrd)')
+        );
+    }
+
+    private function sctXpath(callable $configureTransfer): \DOMXPath
+    {
+        $builder = new CustomerCreditTransferDomBuilder(self::SCT_PAIN);
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = new PaymentInformation('P1', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Origin');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerCreditTransferInformation(100, 'DE40500105174181777145', 'Bob');
+        $transfer->setBic('DEUTDEFF');
+        $configureTransfer($transfer);
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        return $this->xpath($builder->asXml(), self::SCT_PAIN);
+    }
+
+    private function sddXpath(callable $configureTransfer): \DOMXPath
+    {
+        $builder = new CustomerDirectDebitTransferDomBuilder(self::SDD_PAIN);
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerDirectDebitTransferFile($groupHeader);
+        $payment = new PaymentInformation('P1', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Origin');
+        $payment->setSequenceType(PaymentInformation::S_ONEOFF);
+        $payment->setCreditorId('DE67ZZZ00000123456');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerDirectDebitTransferInformation(100, 'DE40500105174181777145', 'Bob');
+        $transfer->setBic('DEUTDEFF');
+        $transfer->setMandateId('M1');
+        $transfer->setMandateSignDate(new \DateTimeImmutable('2022-05-15'));
+        $configureTransfer($transfer);
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        return $this->xpath($builder->asXml(), self::SDD_PAIN);
+    }
+
+    private function xpath(string $xml, string $painFormat): \DOMXPath
+    {
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($xml);
+        $xpath = new \DOMXPath($doc);
+        $xpath->registerNamespace('ns', sprintf('urn:iso:std:iso:20022:tech:xsd:%s', $painFormat));
+        return $xpath;
+    }
+}

--- a/tests/Unit/DomBuilder/UETREmissionTest.php
+++ b/tests/Unit/DomBuilder/UETREmissionTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\DomBuilder;
+
+use Digitick\Sepa\DomBuilder\CustomerCreditTransferDomBuilder;
+use Digitick\Sepa\DomBuilder\CustomerDirectDebitTransferDomBuilder;
+use Digitick\Sepa\GroupHeader;
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferFile\CustomerCreditTransferFile;
+use Digitick\Sepa\TransferFile\CustomerDirectDebitTransferFile;
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
+use Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards against regression of the version-gated UETR element emission rules:
+ *  - SCT: emitted for variant 1, version >= 9.
+ *  - SDD: emitted for variant 1, version >= 8.
+ */
+class UETREmissionTest extends TestCase
+{
+    private const SAMPLE_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+    /**
+     * @dataProvider sctUetrPresentProvider
+     */
+    public function testUETRPresentForSCTVariant1V9Plus(string $painFormat): void
+    {
+        $xml = $this->buildSctXml($painFormat);
+        $xpath = $this->xpath($xml, $painFormat);
+
+        $this->assertSame(
+            self::SAMPLE_UUID,
+            $xpath->evaluate('string(//ns:CdtTrfTxInf/ns:PmtId/ns:UETR)'),
+            'UETR must be emitted for ' . $painFormat
+        );
+    }
+
+    /**
+     * @dataProvider sctUetrAbsentProvider
+     */
+    public function testUETRAbsentForSCTOlderVersionsOrVariants(string $painFormat): void
+    {
+        $xml = $this->buildSctXml($painFormat);
+        $xpath = $this->xpath($xml, $painFormat);
+
+        $this->assertSame(
+            0,
+            $xpath->query('//ns:CdtTrfTxInf/ns:PmtId/ns:UETR')->length,
+            'UETR must not be emitted for ' . $painFormat
+        );
+    }
+
+    /**
+     * @dataProvider sddUetrPresentProvider
+     */
+    public function testUETRPresentForSDDVariant1V8Plus(string $painFormat): void
+    {
+        $xml = $this->buildSddXml($painFormat);
+        $xpath = $this->xpath($xml, $painFormat);
+
+        $this->assertSame(
+            self::SAMPLE_UUID,
+            $xpath->evaluate('string(//ns:DrctDbtTxInf/ns:PmtId/ns:UETR)'),
+            'UETR must be emitted for ' . $painFormat
+        );
+    }
+
+    /**
+     * @dataProvider sddUetrAbsentProvider
+     */
+    public function testUETRAbsentForSDDOlderVersionsOrVariants(string $painFormat): void
+    {
+        $xml = $this->buildSddXml($painFormat);
+        $xpath = $this->xpath($xml, $painFormat);
+
+        $this->assertSame(
+            0,
+            $xpath->query('//ns:DrctDbtTxInf/ns:PmtId/ns:UETR')->length,
+            'UETR must not be emitted for ' . $painFormat
+        );
+    }
+
+    public static function sctUetrPresentProvider(): iterable
+    {
+        return [
+            'pain.001.001.09' => ['pain.001.001.09'],
+            'pain.001.001.10' => ['pain.001.001.10'],
+            'pain.001.001.12' => ['pain.001.001.12'],
+        ];
+    }
+
+    public static function sctUetrAbsentProvider(): iterable
+    {
+        return [
+            'pain.001.001.03' => ['pain.001.001.03'],
+            'pain.001.001.05' => ['pain.001.001.05'],
+            'pain.001.001.08' => ['pain.001.001.08'],
+            // Off-variant formats (variant 2 or 3) must never emit UETR.
+            'pain.001.002.03' => ['pain.001.002.03'],
+            'pain.001.003.03' => ['pain.001.003.03'],
+        ];
+    }
+
+    public static function sddUetrPresentProvider(): iterable
+    {
+        return [
+            'pain.008.001.08' => ['pain.008.001.08'],
+            'pain.008.001.09' => ['pain.008.001.09'],
+            'pain.008.001.10' => ['pain.008.001.10'],
+            'pain.008.001.11' => ['pain.008.001.11'],
+        ];
+    }
+
+    public static function sddUetrAbsentProvider(): iterable
+    {
+        return [
+            'pain.008.001.02' => ['pain.008.001.02'],
+            'pain.008.001.05' => ['pain.008.001.05'],
+            'pain.008.001.07' => ['pain.008.001.07'],
+            // Off-variant must never emit UETR.
+            'pain.008.002.02' => ['pain.008.002.02'],
+            'pain.008.003.02' => ['pain.008.003.02'],
+        ];
+    }
+
+    private function buildSctXml(string $painFormat): string
+    {
+        $builder = new CustomerCreditTransferDomBuilder($painFormat);
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = new PaymentInformation('P1', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Origin');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerCreditTransferInformation(100, 'DE40500105174181777145', 'Bob');
+        $transfer->setBic('DEUTDEFF');
+        $transfer->setUUID(self::SAMPLE_UUID);
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        return $builder->asXml();
+    }
+
+    private function buildSddXml(string $painFormat): string
+    {
+        $builder = new CustomerDirectDebitTransferDomBuilder($painFormat);
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerDirectDebitTransferFile($groupHeader);
+        $payment = new PaymentInformation('P1', 'DE88500105173441451911', 'DEUTDEFFXXX', 'Origin');
+        $payment->setSequenceType(PaymentInformation::S_ONEOFF);
+        $payment->setCreditorId('DE67ZZZ00000123456');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerDirectDebitTransferInformation(100, 'DE40500105174181777145', 'Bob');
+        $transfer->setBic('DEUTDEFF');
+        $transfer->setMandateId('M1');
+        $transfer->setMandateSignDate(new \DateTimeImmutable('2022-05-15'));
+        $transfer->setUUID(self::SAMPLE_UUID);
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        return $builder->asXml();
+    }
+
+    private function xpath(string $xml, string $painFormat): \DOMXPath
+    {
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($xml);
+        $xpath = new \DOMXPath($doc);
+        $xpath->registerNamespace('ns', sprintf('urn:iso:std:iso:20022:tech:xsd:%s', $painFormat));
+        return $xpath;
+    }
+}

--- a/tests/Unit/GroupHeaderTest.php
+++ b/tests/Unit/GroupHeaderTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Digitick\Sepa\GroupHeader;
+use PHPUnit\Framework\TestCase;
+
+class GroupHeaderTest extends TestCase
+{
+    public function testConstructorStoresMessageIdentificationAndInitiatingPartyName(): void
+    {
+        $gh = new GroupHeader('MSG-42', 'Acme Corp');
+
+        $this->assertSame('MSG-42', $gh->getMessageIdentification());
+        $this->assertSame('Acme Corp', $gh->getInitiatingPartyName());
+    }
+
+    public function testIsTestDefaultsToFalse(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme');
+
+        $this->assertFalse($gh->getIsTest());
+    }
+
+    public function testIsTestFlagHonouredByConstructor(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme', true);
+
+        $this->assertTrue($gh->getIsTest());
+    }
+
+    public function testSetIsTestOverridesConstructorValue(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme', false);
+        $gh->setIsTest(true);
+
+        $this->assertTrue($gh->getIsTest());
+    }
+
+    public function testCreationDateTimeIsDateTimeImmutable(): void
+    {
+        $before = new DateTimeImmutable();
+        $gh = new GroupHeader('MSG', 'Acme');
+        $after = new DateTimeImmutable();
+
+        $created = $gh->getCreationDateTime();
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $created);
+        $this->assertGreaterThanOrEqual($before->getTimestamp(), $created->getTimestamp());
+        $this->assertLessThanOrEqual($after->getTimestamp(), $created->getTimestamp());
+    }
+
+    public function testCreationDateTimeFormatDefaultsToRfc3339(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme');
+
+        $this->assertSame(DateTimeInterface::RFC3339, $gh->getCreationDateTimeFormat());
+    }
+
+    public function testCreationDateTimeFormatIsOverridable(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme');
+        $gh->setCreationDateTimeFormat('Y-m-d\TH:i:s.v\Z');
+
+        $this->assertSame('Y-m-d\TH:i:s.v\Z', $gh->getCreationDateTimeFormat());
+    }
+
+    public function testInitiatingPartyNameIsSanitizedOnConstruction(): void
+    {
+        // The default sanitizer strips characters outside the SEPA-allowed
+        // ASCII set and transliterates common accents.
+        $gh = new GroupHeader('MSG', 'Müller & Söhne');
+
+        $this->assertSame('Mueller   Soehne', $gh->getInitiatingPartyName());
+    }
+
+    public function testSetInitiatingPartyNameSanitizes(): void
+    {
+        $gh = new GroupHeader('MSG', 'Placeholder');
+        $gh->setInitiatingPartyName('Jörg Händel');
+
+        $this->assertSame('Joerg Haendel', $gh->getInitiatingPartyName());
+    }
+
+    public function testSetInitiatingPartyIdentificationSchemeSanitizes(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme');
+        $gh->setInitiatingPartyIdentificationScheme('SEPA&');
+
+        $this->assertSame('SEPA ', $gh->getInitiatingPartyIdentificationScheme());
+    }
+
+    public function testInitiatingPartyIdIsNullByDefault(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme');
+
+        $this->assertNull($gh->getInitiatingPartyId());
+    }
+
+    public function testSetInitiatingPartyIdStoresAsIs(): void
+    {
+        // setInitiatingPartyId does not run through the sanitizer; it is
+        // expected to be a controlled identifier.
+        $gh = new GroupHeader('MSG', 'Acme');
+        $gh->setInitiatingPartyId('DE67ZZZ00000123456');
+
+        $this->assertSame('DE67ZZZ00000123456', $gh->getInitiatingPartyId());
+    }
+
+    public function testIssuerDefaultsToNull(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme');
+
+        $this->assertNull($gh->getIssuer());
+    }
+
+    public function testSetIssuer(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme');
+        $gh->setIssuer('Some Bank');
+
+        $this->assertSame('Some Bank', $gh->getIssuer());
+    }
+
+    public function testTransactionCountersDefaultToZero(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme');
+
+        $this->assertSame(0, $gh->getNumberOfTransactions());
+        $this->assertSame(0, $gh->getControlSumCents());
+    }
+
+    public function testTransactionCountersAreSettable(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme');
+        $gh->setNumberOfTransactions(7);
+        $gh->setControlSumCents(12345);
+
+        $this->assertSame(7, $gh->getNumberOfTransactions());
+        $this->assertSame(12345, $gh->getControlSumCents());
+    }
+
+    public function testSetMessageIdentificationOverride(): void
+    {
+        $gh = new GroupHeader('MSG', 'Acme');
+        $gh->setMessageIdentification('NEW-ID');
+
+        $this->assertSame('NEW-ID', $gh->getMessageIdentification());
+    }
+}

--- a/tests/Unit/PaymentInformationTest.php
+++ b/tests/Unit/PaymentInformationTest.php
@@ -6,7 +6,9 @@
 
 namespace Digitick\Sepa\Tests\Unit;
 
+use Digitick\Sepa\Exception\InvalidArgumentException;
 use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
 use PHPUnit\Framework\TestCase;
 
 class PaymentInformationTest extends TestCase
@@ -24,5 +26,122 @@ class PaymentInformationTest extends TestCase
         $pi->setDueDate(new \DateTime('2017-08-31 12:13:14'));
         $pi->setDueDateFormat('d.m.Y');
         $this->assertEquals('31.08.2017', $pi->getDueDate());
+    }
+
+    public function testSetPaymentMethodThrowsWhenValidMethodsEmpty(): void
+    {
+        $pi = new PaymentInformation('1', 'DE12', 'BIC', 'Jon Doe');
+
+        // validPaymentMethods defaults to [], so every value is rejected
+        // until the owning TransferFile configures the allow-list.
+        $this->expectException(InvalidArgumentException::class);
+        $pi->setPaymentMethod('TRF');
+    }
+
+    public function testSetPaymentMethodThrowsForMethodOutsideAllowList(): void
+    {
+        $pi = new PaymentInformation('1', 'DE12', 'BIC', 'Jon Doe');
+        $pi->setValidPaymentMethods(['TRF']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $pi->setPaymentMethod('DD');
+    }
+
+    public function testSetPaymentMethodAcceptsAllowedValueAndNormalisesCase(): void
+    {
+        $pi = new PaymentInformation('1', 'DE12', 'BIC', 'Jon Doe');
+        $pi->setValidPaymentMethods(['TRF']);
+
+        $pi->setPaymentMethod('trf');
+
+        $this->assertSame('TRF', $pi->getPaymentMethod());
+    }
+
+    /**
+     * @dataProvider invalidLocalInstrumentCodeProvider
+     */
+    public function testSetLocalInstrumentCodeThrowsForInvalid(string $code): void
+    {
+        $pi = new PaymentInformation('1', 'DE12', 'BIC', 'Jon Doe');
+
+        $this->expectException(InvalidArgumentException::class);
+        $pi->setLocalInstrumentCode($code);
+    }
+
+    public static function invalidLocalInstrumentCodeProvider(): iterable
+    {
+        return [
+            'empty'       => [''],
+            'unknown'     => ['XYZ'],
+            'typo'        => ['CORE1'],
+            'close-match' => ['B2C'],
+        ];
+    }
+
+    /**
+     * @dataProvider validLocalInstrumentCodeProvider
+     */
+    public function testSetLocalInstrumentCodeAcceptsValidValuesCaseInsensitively(string $input, string $stored): void
+    {
+        $pi = new PaymentInformation('1', 'DE12', 'BIC', 'Jon Doe');
+        $pi->setLocalInstrumentCode($input);
+
+        $this->assertSame($stored, $pi->getLocalInstrumentCode());
+    }
+
+    public static function validLocalInstrumentCodeProvider(): iterable
+    {
+        return [
+            'B2B'        => ['B2B', 'B2B'],
+            'CORE'       => ['CORE', 'CORE'],
+            'COR1'       => ['COR1', 'COR1'],
+            'lower b2b'  => ['b2b', 'B2B'],
+            'lower core' => ['core', 'CORE'],
+        ];
+    }
+
+    public function testSetInstructionPriorityThrowsForInvalid(): void
+    {
+        $pi = new PaymentInformation('1', 'DE12', 'BIC', 'Jon Doe');
+
+        $this->expectException(InvalidArgumentException::class);
+        $pi->setInstructionPriority('URGENT');
+    }
+
+    /**
+     * @dataProvider validInstructionPriorityProvider
+     */
+    public function testSetInstructionPriorityAcceptsValidValuesCaseInsensitively(string $input, string $stored): void
+    {
+        $pi = new PaymentInformation('1', 'DE12', 'BIC', 'Jon Doe');
+        $pi->setInstructionPriority($input);
+
+        $this->assertSame($stored, $pi->getInstructionPriority());
+    }
+
+    public static function validInstructionPriorityProvider(): iterable
+    {
+        return [
+            'NORM'       => ['NORM', 'NORM'],
+            'HIGH'       => ['HIGH', 'HIGH'],
+            'lower norm' => ['norm', 'NORM'],
+            'lower high' => ['high', 'HIGH'],
+        ];
+    }
+
+    public function testAddTransferAccumulatesNumberOfTransactionsAndControlSum(): void
+    {
+        $pi = new PaymentInformation('1', 'DE12', 'BIC', 'Jon Doe');
+
+        $this->assertSame(0, $pi->getNumberOfTransactions());
+        $this->assertSame(0, $pi->getControlSumCents());
+
+        $pi->addTransfer(new CustomerCreditTransferInformation(100, 'DE12', 'A'));
+        $pi->addTransfer(new CustomerCreditTransferInformation(250, 'DE12', 'B'));
+        $pi->addTransfer(new CustomerCreditTransferInformation(7, 'DE12', 'C'));
+
+        $this->assertSame(3, $pi->getNumberOfTransactions());
+        $this->assertSame(357, $pi->getControlSumCents());
+        $this->assertCount(3, $pi->getTransfers());
     }
 }

--- a/tests/Unit/SanitizerOnSetterTest.php
+++ b/tests/Unit/SanitizerOnSetterTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit;
+
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
+use Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation;
+use Digitick\Sepa\Util\Sanitizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks down the contract that specific setters silently route input through
+ * the default Sanitizer. A regression removing Sanitizer::sanitize() from
+ * any of these setters would ship non-transliterated / disallowed characters
+ * to banks that reject them.
+ *
+ * Setters not listed here either do not sanitize by design (e.g. setBic,
+ * setOriginAccountIBAN, setCountry, setPurposeCode — controlled identifiers)
+ * or are already covered in a closer test (GroupHeader setters live in
+ * GroupHeaderTest).
+ */
+class SanitizerOnSetterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Defensive: ensure no prior test has installed a custom / disabled
+        // sanitizer that would leak through to the assertions below.
+        Sanitizer::resetSanitizer();
+    }
+
+    protected function tearDown(): void
+    {
+        Sanitizer::resetSanitizer();
+    }
+
+    /**
+     * @dataProvider baseTransferInformationSetters
+     */
+    public function testBaseTransferInformationSetterSanitizes(
+        string $setter,
+        string $getter,
+        string $input,
+        string $expected
+    ): void {
+        $obj = new CustomerCreditTransferInformation(100, 'DE12500105170648489890', 'Placeholder');
+        $obj->$setter($input);
+
+        $this->assertSame($expected, $obj->$getter());
+    }
+
+    public static function baseTransferInformationSetters(): iterable
+    {
+        return [
+            'setName'                    => ['setName', 'getName', 'Jörg', 'Joerg'],
+            'setEndToEndIdentification'  => ['setEndToEndIdentification', 'getEndToEndIdentification', 'Müller-E2E', 'Mueller-E2E'],
+            'setCreditorReference'       => ['setCreditorReference', 'getCreditorReference', 'RFä42', 'RFae42'],
+            'setCreditorReferenceType'   => ['setCreditorReferenceType', 'getCreditorReferenceType', 'ISO&11649', 'ISO 11649'],
+            'setRemittanceInformation'   => ['setRemittanceInformation', 'getRemittanceInformation', 'Rechnung Nr. ä42', 'Rechnung Nr. ae42'],
+            'setTownName'                => ['setTownName', 'getTownName', 'München', 'Muenchen'],
+            'setPostCode'                => ['setPostCode', 'getPostCode', '12345ä', '12345ae'],
+            'setStreetName'              => ['setStreetName', 'getStreetName', 'Hauptstraße 1', 'Hauptstrasse 1'],
+            'setBuildingNumber'          => ['setBuildingNumber', 'getBuildingNumber', '14ä', '14ae'],
+            'setFloorNumber'             => ['setFloorNumber', 'getFloorNumber', '3ö', '3oe'],
+            'combined transliterate+strip' => ['setName', 'getName', 'Jörg & Händel', 'Joerg   Haendel'],
+        ];
+    }
+
+    /**
+     * @dataProvider customerDirectDebitTransferInformationSetters
+     */
+    public function testCustomerDirectDebitTransferInformationSetterSanitizes(
+        string $setter,
+        string $getter,
+        string $input,
+        string $expected
+    ): void {
+        $obj = new CustomerDirectDebitTransferInformation(100, 'DE12500105170648489890', 'Placeholder');
+        $obj->$setter($input);
+
+        $this->assertSame($expected, $obj->$getter());
+    }
+
+    public static function customerDirectDebitTransferInformationSetters(): iterable
+    {
+        return [
+            'setMandateId'         => ['setMandateId', 'getMandateId', 'MANDä-1', 'MANDae-1'],
+            'setOriginalMandateId' => ['setOriginalMandateId', 'getOriginalMandateId', 'OLDMä-42', 'OLDMae-42'],
+        ];
+    }
+
+    /**
+     * @dataProvider paymentInformationSetters
+     */
+    public function testPaymentInformationSetterSanitizes(
+        string $setter,
+        string $getter,
+        string $input,
+        string $expected
+    ): void {
+        $obj = new PaymentInformation('id', 'DE12500105170648489890', 'BIC', 'Placeholder');
+        $obj->$setter($input);
+
+        $this->assertSame($expected, $obj->$getter());
+    }
+
+    public static function paymentInformationSetters(): iterable
+    {
+        return [
+            'setCreditorId'                          => ['setCreditorId', 'getCreditorId', 'DE67ZZZä00000123456', 'DE67ZZZae00000123456'],
+            'setOriginName'                          => ['setOriginName', 'getOriginName', 'Jörg GmbH', 'Joerg GmbH'],
+            'setOriginBankPartyIdentification'       => ['setOriginBankPartyIdentification', 'getOriginBankPartyIdentification', 'BNKä-1', 'BNKae-1'],
+            'setOriginBankPartyIdentificationScheme' => ['setOriginBankPartyIdentificationScheme', 'getOriginBankPartyIdentificationScheme', 'BNK&', 'BNK '],
+        ];
+    }
+
+    public function testConstructorArgumentNameIsSanitized(): void
+    {
+        $obj = new CustomerCreditTransferInformation(100, 'DE12500105170648489890', 'Jörg');
+
+        $this->assertSame('Joerg', $obj->getName());
+    }
+
+    public function testConstructorArgumentIdentificationIsSanitized(): void
+    {
+        $obj = new CustomerCreditTransferInformation(100, 'DE12500105170648489890', 'Placeholder', 'Jörg');
+
+        $this->assertSame('Joerg', $obj->getEndToEndIdentification());
+    }
+
+    public function testPaymentInformationConstructorSanitizesOriginName(): void
+    {
+        $obj = new PaymentInformation('id', 'DE12500105170648489890', 'BIC', 'Jörg GmbH');
+
+        $this->assertSame('Joerg GmbH', $obj->getOriginName());
+    }
+
+    public function testAddressSettersTreatEmptyStringAsNull(): void
+    {
+        $obj = new CustomerCreditTransferInformation(100, 'DE12500105170648489890', 'Placeholder');
+
+        // These setters short-circuit the Sanitizer call when the value is
+        // empty (per BaseTransferInformation::setTownName et al. — the
+        // "!empty ? sanitize : null" branch).
+        $obj->setTownName('');
+        $obj->setPostCode('');
+        $obj->setStreetName('');
+        $obj->setBuildingNumber('');
+        $obj->setFloorNumber('');
+
+        $this->assertNull($obj->getTownName());
+        $this->assertNull($obj->getPostCode());
+        $this->assertNull($obj->getStreetName());
+        $this->assertNull($obj->getBuildingNumber());
+        $this->assertNull($obj->getFloorNumber());
+    }
+}

--- a/tests/Unit/TransferFile/CustomerCreditTransferFileTest.php
+++ b/tests/Unit/TransferFile/CustomerCreditTransferFileTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\TransferFile;
+
+use Digitick\Sepa\Exception\InvalidTransferFileConfiguration;
+use Digitick\Sepa\Exception\InvalidTransferTypeException;
+use Digitick\Sepa\GroupHeader;
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferFile\CustomerCreditTransferFile;
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
+use Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation;
+use PHPUnit\Framework\TestCase;
+
+class CustomerCreditTransferFileTest extends TestCase
+{
+    public function testAddPaymentInformationForcesTrfPaymentMethod(): void
+    {
+        $file = new CustomerCreditTransferFile(new GroupHeader('MSG', 'Acme'));
+        $payment = $this->newValidPayment();
+
+        $file->addPaymentInformation($payment);
+
+        $this->assertSame('TRF', $payment->getPaymentMethod());
+    }
+
+    public function testAddPaymentInformationAccumulatesGroupHeaderCounters(): void
+    {
+        $header = new GroupHeader('MSG', 'Acme');
+        $file = new CustomerCreditTransferFile($header);
+
+        $payment = $this->newValidPayment();
+        $payment->addTransfer(new CustomerCreditTransferInformation(100, 'DE12', 'A'));
+        $payment->addTransfer(new CustomerCreditTransferInformation(250, 'DE12', 'B'));
+
+        $file->addPaymentInformation($payment);
+
+        $this->assertSame(2, $header->getNumberOfTransactions());
+        $this->assertSame(350, $header->getControlSumCents());
+    }
+
+    public function testValidateThrowsWhenNoPaymentInformationAdded(): void
+    {
+        $file = new CustomerCreditTransferFile(new GroupHeader('MSG', 'Acme'));
+
+        $this->expectException(InvalidTransferFileConfiguration::class);
+        $file->validate();
+    }
+
+    public function testValidateThrowsWhenPaymentHasNoTransfers(): void
+    {
+        $file = new CustomerCreditTransferFile(new GroupHeader('MSG', 'Acme'));
+        $file->addPaymentInformation($this->newValidPayment());
+
+        $this->expectException(InvalidTransferFileConfiguration::class);
+        $this->expectExceptionMessage('PaymentInformation must at least contain one payment');
+        $file->validate();
+    }
+
+    public function testValidateThrowsWhenTransferIsWrongType(): void
+    {
+        $file = new CustomerCreditTransferFile(new GroupHeader('MSG', 'Acme'));
+        $payment = $this->newValidPayment();
+        $payment->addTransfer(new CustomerDirectDebitTransferInformation(100, 'DE12', 'Alice'));
+        $file->addPaymentInformation($payment);
+
+        $this->expectException(InvalidTransferTypeException::class);
+        $file->validate();
+    }
+
+    public function testValidateAcceptsValidFile(): void
+    {
+        $file = new CustomerCreditTransferFile(new GroupHeader('MSG', 'Acme'));
+        $payment = $this->newValidPayment();
+        $payment->addTransfer(new CustomerCreditTransferInformation(100, 'DE12', 'Alice'));
+        $file->addPaymentInformation($payment);
+
+        $file->validate();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testGetGroupHeaderReturnsInjectedInstance(): void
+    {
+        $header = new GroupHeader('MSG', 'Acme');
+        $file = new CustomerCreditTransferFile($header);
+
+        $this->assertSame($header, $file->getGroupHeader());
+    }
+
+    private function newValidPayment(): PaymentInformation
+    {
+        return new PaymentInformation('pay1', 'DE12', 'BIC', 'Origin');
+    }
+}

--- a/tests/Unit/TransferFile/CustomerDirectDebitTransferFileTest.php
+++ b/tests/Unit/TransferFile/CustomerDirectDebitTransferFileTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\TransferFile;
+
+use DateTimeImmutable;
+use Digitick\Sepa\Exception\InvalidTransferFileConfiguration;
+use Digitick\Sepa\Exception\InvalidTransferTypeException;
+use Digitick\Sepa\GroupHeader;
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferFile\CustomerDirectDebitTransferFile;
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
+use Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation;
+use PHPUnit\Framework\TestCase;
+
+class CustomerDirectDebitTransferFileTest extends TestCase
+{
+    public function testAddPaymentInformationForcesDdPaymentMethod(): void
+    {
+        $file = new CustomerDirectDebitTransferFile(new GroupHeader('MSG', 'Acme'));
+        $payment = $this->newValidPayment();
+
+        $file->addPaymentInformation($payment);
+
+        $this->assertSame('DD', $payment->getPaymentMethod());
+    }
+
+    public function testAddPaymentInformationAccumulatesGroupHeaderCounters(): void
+    {
+        $header = new GroupHeader('MSG', 'Acme');
+        $file = new CustomerDirectDebitTransferFile($header);
+
+        $payment = $this->newValidPayment();
+        $payment->addTransfer($this->newValidTransfer(100));
+        $payment->addTransfer($this->newValidTransfer(250));
+
+        $file->addPaymentInformation($payment);
+
+        $this->assertSame(2, $header->getNumberOfTransactions());
+        $this->assertSame(350, $header->getControlSumCents());
+    }
+
+    public function testValidateThrowsWhenNoPaymentInformationAdded(): void
+    {
+        $file = new CustomerDirectDebitTransferFile(new GroupHeader('MSG', 'Acme'));
+
+        $this->expectException(InvalidTransferFileConfiguration::class);
+        $file->validate();
+    }
+
+    public function testValidateThrowsWhenSequenceTypeMissing(): void
+    {
+        $file = new CustomerDirectDebitTransferFile(new GroupHeader('MSG', 'Acme'));
+        $payment = $this->newValidPayment();
+        // Clear the field the factory helper pre-sets.
+        $payment->setSequenceType('');
+        $file->addPaymentInformation($payment);
+
+        $this->expectException(InvalidTransferFileConfiguration::class);
+        $this->expectExceptionMessage('SequenceType');
+        $file->validate();
+    }
+
+    public function testValidateThrowsWhenCreditorIdMissing(): void
+    {
+        $file = new CustomerDirectDebitTransferFile(new GroupHeader('MSG', 'Acme'));
+        $payment = new PaymentInformation('pay1', 'DE12', 'BIC', 'Origin');
+        $payment->setSequenceType(PaymentInformation::S_ONEOFF);
+        // Deliberately omit setCreditorId().
+        $file->addPaymentInformation($payment);
+
+        $this->expectException(InvalidTransferFileConfiguration::class);
+        $this->expectExceptionMessage('CreditorSchemeId');
+        $file->validate();
+    }
+
+    public function testValidateThrowsWhenTransferIsWrongType(): void
+    {
+        $file = new CustomerDirectDebitTransferFile(new GroupHeader('MSG', 'Acme'));
+        $payment = $this->newValidPayment();
+        $payment->addTransfer(new CustomerCreditTransferInformation(100, 'DE12', 'Alice'));
+        $file->addPaymentInformation($payment);
+
+        $this->expectException(InvalidTransferTypeException::class);
+        $file->validate();
+    }
+
+    public function testValidateAcceptsValidFile(): void
+    {
+        $file = new CustomerDirectDebitTransferFile(new GroupHeader('MSG', 'Acme'));
+        $payment = $this->newValidPayment();
+        $payment->addTransfer($this->newValidTransfer(100));
+        $file->addPaymentInformation($payment);
+
+        $file->validate();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testGetGroupHeaderReturnsInjectedInstance(): void
+    {
+        $header = new GroupHeader('MSG', 'Acme');
+        $file = new CustomerDirectDebitTransferFile($header);
+
+        $this->assertSame($header, $file->getGroupHeader());
+    }
+
+    private function newValidPayment(): PaymentInformation
+    {
+        $payment = new PaymentInformation('pay1', 'DE12', 'BIC', 'Origin');
+        $payment->setSequenceType(PaymentInformation::S_ONEOFF);
+        $payment->setCreditorId('DE67ZZZ00000123456');
+
+        return $payment;
+    }
+
+    private function newValidTransfer(int $amount): CustomerDirectDebitTransferInformation
+    {
+        $transfer = new CustomerDirectDebitTransferInformation($amount, 'DE12', 'Debtor');
+        $transfer->setMandateId('M1');
+        $transfer->setMandateSignDate(new DateTimeImmutable('2022-05-15'));
+
+        return $transfer;
+    }
+}

--- a/tests/Unit/TransferFile/Facade/CustomerCreditFacadeTest.php
+++ b/tests/Unit/TransferFile/Facade/CustomerCreditFacadeTest.php
@@ -118,4 +118,37 @@ class CustomerCreditFacadeTest extends TestCase
             'pain.001.001.11' => ['pain.001.001.12']
         ];
     }
+
+    public function testAddPaymentInfoThrowsWhenNameAlreadyExists(): void
+    {
+        $credit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me', 'pain.001.001.09');
+        $credit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'debtorName' => 'Me',
+            'debtorAccountIBAN' => 'FI1350001540000056',
+            'debtorAgentBIC' => 'PSSTFRPPMON',
+        ]);
+
+        $this->expectException(\Digitick\Sepa\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Payment with the name firstPayment already exists');
+        $credit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'debtorName' => 'Me',
+            'debtorAccountIBAN' => 'FI1350001540000056',
+        ]);
+    }
+
+    public function testAddTransferThrowsWhenPaymentDoesNotExist(): void
+    {
+        $credit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me', 'pain.001.001.09');
+
+        $this->expectException(\Digitick\Sepa\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Payment with the name missing does not exists');
+        $credit->addTransfer('missing', [
+            'amount' => 500,
+            'creditorIban' => 'FI1350001540000056',
+            'creditorName' => 'Their Company',
+            'remittanceInformation' => 'x',
+        ]);
+    }
 }

--- a/tests/Unit/TransferFile/Facade/CustomerDirectDebitFacadeTest.php
+++ b/tests/Unit/TransferFile/Facade/CustomerDirectDebitFacadeTest.php
@@ -351,4 +351,43 @@ class CustomerDirectDebitFacadeTest extends TestCase
             'pain.008.001.11' => ['pain.008.001.11'],
         ];
     }
+
+    public function testAddPaymentInfoThrowsWhenNameAlreadyExists(): void
+    {
+        $directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me', 'pain.008.001.02');
+        $directDebit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'creditorName' => 'Me',
+            'creditorAccountIBAN' => 'FI1350001540000056',
+            'creditorAgentBIC' => 'PSSTFRPPMON',
+            'seqType' => PaymentInformation::S_ONEOFF,
+            'creditorId' => 'DE21WVM1234567890',
+        ]);
+
+        $this->expectException(\Digitick\Sepa\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Payment with the name firstPayment already exists');
+        $directDebit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'creditorName' => 'Me',
+            'creditorAccountIBAN' => 'FI1350001540000056',
+            'seqType' => PaymentInformation::S_ONEOFF,
+            'creditorId' => 'DE21WVM1234567890',
+        ]);
+    }
+
+    public function testAddTransferThrowsWhenPaymentDoesNotExist(): void
+    {
+        $directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me', 'pain.008.001.02');
+
+        $this->expectException(\Digitick\Sepa\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Payment with the name missing does not exists');
+        $directDebit->addTransfer('missing', [
+            'amount' => 500,
+            'debtorIban' => 'FI1350001540000056',
+            'debtorName' => 'Their Company',
+            'debtorMandate' => 'M1',
+            'debtorMandateSignDate' => '2022-05-15',
+            'remittanceInformation' => 'x',
+        ]);
+    }
 }

--- a/tests/Unit/TransferFile/Factory/TransferFileFacadeFactoryTest.php
+++ b/tests/Unit/TransferFile/Factory/TransferFileFacadeFactoryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\TransferFile\Factory;
+
+use Digitick\Sepa\GroupHeader;
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferFile\Facade\CustomerCreditFacade;
+use Digitick\Sepa\TransferFile\Facade\CustomerDirectDebitFacade;
+use Digitick\Sepa\TransferFile\Factory\TransferFileFacadeFactory;
+use PHPUnit\Framework\TestCase;
+
+class TransferFileFacadeFactoryTest extends TestCase
+{
+    public function testCreateCustomerCreditReturnsCreditFacade(): void
+    {
+        $facade = TransferFileFacadeFactory::createCustomerCredit('MSG', 'Init', 'pain.001.001.09');
+
+        $this->assertInstanceOf(CustomerCreditFacade::class, $facade);
+    }
+
+    public function testCreateCustomerCreditDefaultPainFormatProducesValidDocument(): void
+    {
+        $facade = TransferFileFacadeFactory::createCustomerCredit('MSG', 'Init');
+        $facade->addPaymentInfo('p', [
+            'id' => 'p',
+            'debtorName' => 'Me',
+            'debtorAccountIBAN' => 'DE88500105173441451911',
+            'debtorAgentBIC' => 'DEUTDEFF',
+        ]);
+        $facade->addTransfer('p', [
+            'amount' => 100,
+            'creditorIban' => 'DE40500105174181777145',
+            'creditorName' => 'Bob',
+            'remittanceInformation' => 'x',
+        ]);
+
+        $xml = $facade->asXML();
+        $this->assertStringContainsString('pain.001.001.09', $xml);
+    }
+
+    public function testCreateCustomerCreditWithGroupHeaderPreservesHeader(): void
+    {
+        $header = new GroupHeader('CUSTOM-ID', 'Company', true);
+        $header->setIssuer('IssuerName');
+
+        $facade = TransferFileFacadeFactory::createCustomerCreditWithGroupHeader($header, 'pain.001.001.09');
+        $facade->addPaymentInfo('p', [
+            'id' => 'p',
+            'debtorName' => 'Me',
+            'debtorAccountIBAN' => 'DE88500105173441451911',
+            'debtorAgentBIC' => 'DEUTDEFF',
+        ]);
+        $facade->addTransfer('p', [
+            'amount' => 100,
+            'creditorIban' => 'DE40500105174181777145',
+            'creditorName' => 'Bob',
+            'remittanceInformation' => 'x',
+        ]);
+
+        $xml = $facade->asXML();
+        $this->assertStringContainsString('<MsgId>CUSTOM-ID</MsgId>', $xml);
+    }
+
+    public function testCreateCustomerCreditWithGroupHeaderHonoursWithSchemaLocationFalse(): void
+    {
+        $header = new GroupHeader('MSG', 'Company');
+
+        $facade = TransferFileFacadeFactory::createCustomerCreditWithGroupHeader(
+            $header,
+            'pain.001.001.09',
+            false
+        );
+        $facade->addPaymentInfo('p', [
+            'id' => 'p',
+            'debtorName' => 'Me',
+            'debtorAccountIBAN' => 'DE88500105173441451911',
+            'debtorAgentBIC' => 'DEUTDEFF',
+        ]);
+        $facade->addTransfer('p', [
+            'amount' => 100,
+            'creditorIban' => 'DE40500105174181777145',
+            'creditorName' => 'Bob',
+            'remittanceInformation' => 'x',
+        ]);
+
+        $xml = $facade->asXML();
+        $this->assertStringNotContainsString('xsi:schemaLocation', $xml);
+    }
+
+    public function testCreateDirectDebitReturnsDirectDebitFacade(): void
+    {
+        $facade = TransferFileFacadeFactory::createDirectDebit('MSG', 'Init', 'pain.008.001.02');
+
+        $this->assertInstanceOf(CustomerDirectDebitFacade::class, $facade);
+    }
+
+    public function testCreateDirectDebitWithGroupHeaderPreservesHeader(): void
+    {
+        $header = new GroupHeader('CUSTOM-ID', 'Company');
+
+        $facade = TransferFileFacadeFactory::createDirectDebitWithGroupHeader($header, 'pain.008.001.02');
+        $facade->addPaymentInfo('p', [
+            'id' => 'p',
+            'creditorName' => 'Me',
+            'creditorAccountIBAN' => 'DE88500105173441451911',
+            'creditorAgentBIC' => 'DEUTDEFF',
+            'seqType' => PaymentInformation::S_ONEOFF,
+            'creditorId' => 'DE67ZZZ00000123456',
+        ]);
+        $facade->addTransfer('p', [
+            'amount' => 100,
+            'debtorIban' => 'DE40500105174181777145',
+            'debtorBic' => 'DEUTDEFF',
+            'debtorName' => 'Bob',
+            'debtorMandate' => 'M1',
+            'debtorMandateSignDate' => '2022-05-15',
+            'remittanceInformation' => 'x',
+        ]);
+
+        $xml = $facade->asXML();
+        $this->assertStringContainsString('<MsgId>CUSTOM-ID</MsgId>', $xml);
+    }
+}


### PR DESCRIPTION
- `PaymentInformation` setter validation — throw paths for `setPaymentMethod`, `setLocalInstrumentCode`, `setInstructionPriority`, plus case-insensitive normalisation and `addTransfer` counter accumulation.
- `GroupHeader` unit tests — constructor defaults and overrides, sanitization on setters, counter setters, creation-date-format override, identifier-setter round-tripping.
- `CustomerCreditTransferFile` and `CustomerDirectDebitTransferFile` unit tests — `validate()` throw paths, payment-method forcing, group-header counter accumulation.
- `CustomerCreditTransferDomBuilder` dedicated unit test paralleling the SDD test — XSD validation across 9 PAIN versions, structured address rendering, `ReqdExctnDt` variant gating, OrgId replacement, `CategoryPurposeCode`, `LocalInstrumentCode`/`Proprietary` XOR and `InstructionPriority` gating.
- UETR emission gating — positive and negative cases for SCT variant 1 v>=9 and SDD variant 1 v>=8 across 17 data points.
- `BaseDomBuilder::getFinancialInstitutionElement` branch tests — `BIC`, `BICFI` and `NOTPROVIDED` fallback for both builders.
- Direct-debit amendment XPath tests — `SMNDA OrgnlDbtrAcct` and `OrgnlMndtId` emission; absence when no amendments set.
- SCT and SDD STP variant-2/3 `PstlAdr` restriction tests — structured address fields suppressed under `pain.001.002.03`, `pain.001.003.03`, `pain.008.002.02`, `pain.008.003.02`.
- Facade error-path tests — duplicate payment name on `addPaymentInfo` and missing payment on `addTransfer` for both facades.
- `DomBuilderFactory` unknown-class throw test.
- `TransferFileFacadeFactory` tests — `createCustomer*WithGroupHeader` variants and the `withSchemaLocation=false` branch.
- Structured remittance (SCOR) XPath tests for both builders — `Strd/CdtrRefInf` shape with and without `Issr`, and the creditor-reference-over-unstructured precedence rule.
- `BaseDomBuilder::intToCurrency` isolated formatter tests — 8 amount edge cases plus locale-insensitivity checks for Spanish, French and German locales.
- Sanitizer-on-setter contract tests — `BaseTransferInformation` (10 setters), `CustomerDirectDebitTransferInformation` (2), `PaymentInformation` (4), plus constructor paths and the empty-string-to-null address-setter short-circuit.

Test count rose from 405 (master) to 568 (+163 tests, +313 assertions). PHPStan remains clean.