### PR TITLE
Feature/as xml idempotency

### DIFF
--- a/src/TransferFile/Facade/BaseCustomerTransferFileFacade.php
+++ b/src/TransferFile/Facade/BaseCustomerTransferFileFacade.php
@@ -48,6 +48,19 @@ abstract class BaseCustomerTransferFileFacade implements CustomerTransferFileFac
      */
     protected $payments = [];
 
+    /**
+     * @var bool Whether the document has been rendered. Guards against
+     *           re-flushing payments into the transfer file (which would
+     *           double the NbOfTxs / CtrlSum counters on GroupHeader and
+     *           duplicate <PmtInf> nodes in the DOM).
+     */
+    private $rendered = false;
+
+    /**
+     * @var string|null Cached XML produced by the first render.
+     */
+    private $renderedXml;
+
     public function __construct(TransferFileInterface $transferFile, BaseDomBuilder $domBuilder)
     {
         $this->transferFile = $transferFile;
@@ -64,22 +77,35 @@ abstract class BaseCustomerTransferFileFacade implements CustomerTransferFileFac
 
     public function asXML(): string
     {
-        foreach ($this->payments as $payment) {
-            $this->transferFile->addPaymentInformation($payment);
-        }
-        $this->transferFile->accept($this->domBuilder);
+        $this->finalize();
 
-        return $this->domBuilder->asXml();
+        return $this->renderedXml;
     }
 
     public function asDOC(): DOMDocument
     {
+        $this->finalize();
+
+        return $this->domBuilder->asDoc();
+    }
+
+    /**
+     * Flush queued payments into the transfer file, walk it with the
+     * DomBuilder, and cache the result. Safe to call repeatedly — only the
+     * first invocation performs work.
+     */
+    private function finalize(): void
+    {
+        if ($this->rendered) {
+            return;
+        }
+
         foreach ($this->payments as $payment) {
             $this->transferFile->addPaymentInformation($payment);
         }
         $this->transferFile->accept($this->domBuilder);
-
-        return $this->domBuilder->asDoc();
+        $this->renderedXml = $this->domBuilder->asXml();
+        $this->rendered = true;
     }
 
     /**

--- a/src/TransferFile/Facade/BaseCustomerTransferFileFacade.php
+++ b/src/TransferFile/Facade/BaseCustomerTransferFileFacade.php
@@ -90,6 +90,23 @@ abstract class BaseCustomerTransferFileFacade implements CustomerTransferFileFac
     }
 
     /**
+     * Guard used by subclasses to refuse mutation after the document has
+     * been rendered. Otherwise the new payments/transfers would be silently
+     * ignored by the cached XML.
+     *
+     * @throws \LogicException when asXML() or asDOC() has already been called.
+     */
+    protected function ensureNotFinalized(): void
+    {
+        if ($this->rendered) {
+            throw new \LogicException(
+                'Cannot modify a facade after asXML() or asDOC() has been called; '
+                . 'create a new facade instead.'
+            );
+        }
+    }
+
+    /**
      * Flush queued payments into the transfer file, walk it with the
      * DomBuilder, and cache the result. Safe to call repeatedly — only the
      * first invocation performs work.

--- a/src/TransferFile/Facade/CustomerCreditFacade.php
+++ b/src/TransferFile/Facade/CustomerCreditFacade.php
@@ -29,6 +29,7 @@ class CustomerCreditFacade extends BaseCustomerTransferFileFacade
      */
     public function addPaymentInfo(string $paymentName, array $paymentInformation): PaymentInformation
     {
+        $this->ensureNotFinalized();
         if (isset($this->payments[$paymentName])) {
             throw new InvalidArgumentException(sprintf('Payment with the name %s already exists', $paymentName));
         }
@@ -66,6 +67,7 @@ class CustomerCreditFacade extends BaseCustomerTransferFileFacade
      */
     public function addTransfer(string $paymentName, array $transferInformation): TransferInformationInterface
     {
+        $this->ensureNotFinalized();
         if (!isset($this->payments[$paymentName])) {
             throw new InvalidArgumentException(sprintf(
                 'Payment with the name %s does not exists, create one first with addPaymentInfo',

--- a/src/TransferFile/Facade/CustomerDirectDebitFacade.php
+++ b/src/TransferFile/Facade/CustomerDirectDebitFacade.php
@@ -50,6 +50,7 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
      */
     public function addPaymentInfo(string $paymentName, array $paymentInformation): PaymentInformation
     {
+        $this->ensureNotFinalized();
         if (isset($this->payments[$paymentName])) {
             throw new InvalidArgumentException(sprintf('Payment with the name %s already exists', $paymentName));
         }
@@ -104,6 +105,7 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
      */
     public function addTransfer(string $paymentName, array $transferInformation): TransferInformationInterface
     {
+        $this->ensureNotFinalized();
         if (!isset($this->payments[$paymentName])) {
             throw new InvalidArgumentException(sprintf(
                 'Payment with the name %s does not exists, create one first with addPaymentInfo',

--- a/tests/Unit/TransferFile/Facade/FacadeIdempotencyTest.php
+++ b/tests/Unit/TransferFile/Facade/FacadeIdempotencyTest.php
@@ -144,6 +144,123 @@ class FacadeIdempotencyTest extends TestCase
         $this->assertSame(1, $xpath->query('//sepa:PmtInf')->length);
     }
 
+    public function testCustomerCreditAddPaymentInfoAfterRenderThrows(): void
+    {
+        $credit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me', 'pain.001.001.09');
+        $credit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'debtorName' => 'My Company',
+            'debtorAccountIBAN' => 'FI1350001540000056',
+            'debtorAgentBIC' => 'PSSTFRPPMON',
+        ]);
+        $credit->addTransfer('firstPayment', [
+            'amount' => 500,
+            'creditorIban' => 'FI1350001540000056',
+            'creditorName' => 'Their Company',
+            'remittanceInformation' => 'x',
+        ]);
+        $credit->asXML();
+
+        $this->expectException(\LogicException::class);
+        $credit->addPaymentInfo('secondPayment', [
+            'id' => 'secondPayment',
+            'debtorName' => 'My Company',
+            'debtorAccountIBAN' => 'FI1350001540000056',
+        ]);
+    }
+
+    public function testCustomerCreditAddTransferAfterRenderThrows(): void
+    {
+        $credit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me', 'pain.001.001.09');
+        $credit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'debtorName' => 'My Company',
+            'debtorAccountIBAN' => 'FI1350001540000056',
+            'debtorAgentBIC' => 'PSSTFRPPMON',
+        ]);
+        $credit->addTransfer('firstPayment', [
+            'amount' => 500,
+            'creditorIban' => 'FI1350001540000056',
+            'creditorName' => 'Their Company',
+            'remittanceInformation' => 'x',
+        ]);
+        $credit->asXML();
+
+        $this->expectException(\LogicException::class);
+        $credit->addTransfer('firstPayment', [
+            'amount' => 100,
+            'creditorIban' => 'FI1350001540000056',
+            'creditorName' => 'Their Company',
+            'remittanceInformation' => 'x',
+        ]);
+    }
+
+    public function testDirectDebitAddPaymentInfoAfterRenderThrows(): void
+    {
+        $directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me', 'pain.008.001.02');
+        $directDebit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'creditorName' => 'My Company',
+            'creditorAccountIBAN' => 'FI1350001540000056',
+            'creditorAgentBIC' => 'PSSTFRPPMON',
+            'seqType' => PaymentInformation::S_ONEOFF,
+            'creditorId' => 'DE21WVM1234567890',
+        ]);
+        $directDebit->addTransfer('firstPayment', [
+            'amount' => 500,
+            'debtorIban' => 'FI1350001540000056',
+            'debtorBic' => 'OKOYFIHH',
+            'debtorName' => 'Their Company',
+            'debtorMandate' => 'AB12345',
+            'debtorMandateSignDate' => '13.10.2012',
+            'remittanceInformation' => 'x',
+        ]);
+        $directDebit->asXML();
+
+        $this->expectException(\LogicException::class);
+        $directDebit->addPaymentInfo('secondPayment', [
+            'id' => 'secondPayment',
+            'creditorName' => 'My Company',
+            'creditorAccountIBAN' => 'FI1350001540000056',
+            'seqType' => PaymentInformation::S_ONEOFF,
+            'creditorId' => 'DE21WVM1234567890',
+        ]);
+    }
+
+    public function testDirectDebitAddTransferAfterRenderThrows(): void
+    {
+        $directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me', 'pain.008.001.02');
+        $directDebit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'creditorName' => 'My Company',
+            'creditorAccountIBAN' => 'FI1350001540000056',
+            'creditorAgentBIC' => 'PSSTFRPPMON',
+            'seqType' => PaymentInformation::S_ONEOFF,
+            'creditorId' => 'DE21WVM1234567890',
+        ]);
+        $directDebit->addTransfer('firstPayment', [
+            'amount' => 500,
+            'debtorIban' => 'FI1350001540000056',
+            'debtorBic' => 'OKOYFIHH',
+            'debtorName' => 'Their Company',
+            'debtorMandate' => 'AB12345',
+            'debtorMandateSignDate' => '13.10.2012',
+            'remittanceInformation' => 'x',
+        ]);
+        $directDebit->asXML();
+
+        $this->expectException(\LogicException::class);
+        $directDebit->addTransfer('firstPayment', [
+            'amount' => 100,
+            'debtorIban' => 'FI1350001540000056',
+            'debtorBic' => 'OKOYFIHH',
+            'debtorName' => 'Their Company',
+            'debtorMandate' => 'AB12345',
+            'debtorMandateSignDate' => '13.10.2012',
+            'remittanceInformation' => 'x',
+        ]);
+    }
+
     private function xpath(string $xml, string $painFormat): \DOMXPath
     {
         $doc = new \DOMDocument('1.0', 'UTF-8');

--- a/tests/Unit/TransferFile/Facade/FacadeIdempotencyTest.php
+++ b/tests/Unit/TransferFile/Facade/FacadeIdempotencyTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\TransferFile\Facade;
+
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferFile\Factory\TransferFileFacadeFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards against regression of the "calling asXML()/asDOC() twice mutates state"
+ * bug (see IMPROVEMENTS.md #3). Repeated rendering must be idempotent.
+ */
+class FacadeIdempotencyTest extends TestCase
+{
+    public function testCustomerCreditAsXmlIsIdempotent(): void
+    {
+        $credit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me', 'pain.001.001.09');
+        $credit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'debtorName' => 'My Company',
+            'debtorAccountIBAN' => 'FI1350001540000056',
+            'debtorAgentBIC' => 'PSSTFRPPMON',
+        ]);
+        $credit->addTransfer('firstPayment', [
+            'amount' => 500,
+            'creditorIban' => 'FI1350001540000056',
+            'creditorBic' => 'OKOYFIHH',
+            'creditorName' => 'Their Company',
+            'remittanceInformation' => 'Purpose of this credit',
+        ]);
+
+        $firstXml = $credit->asXML();
+        $secondXml = $credit->asXML();
+
+        $this->assertSame($firstXml, $secondXml, 'asXML() must produce identical output across repeated calls');
+
+        $xpath = $this->xpath($secondXml, 'pain.001.001.09');
+
+        $this->assertSame(
+            '1',
+            $xpath->evaluate('string(//sepa:GrpHdr/sepa:NbOfTxs)'),
+            'GrpHdr/NbOfTxs must equal 1, not 2'
+        );
+        $this->assertSame(
+            '5.00',
+            $xpath->evaluate('string(//sepa:GrpHdr/sepa:CtrlSum)'),
+            'GrpHdr/CtrlSum must equal 5.00, not 10.00'
+        );
+        $this->assertSame(
+            1,
+            $xpath->query('//sepa:CstmrCdtTrfInitn')->length,
+            'Document must contain exactly one CstmrCdtTrfInitn element'
+        );
+        $this->assertSame(
+            1,
+            $xpath->query('//sepa:PmtInf')->length,
+            'Document must contain exactly one PmtInf element'
+        );
+    }
+
+    public function testCustomerCreditAsDocIsIdempotent(): void
+    {
+        $credit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me', 'pain.001.001.09');
+        $credit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'debtorName' => 'My Company',
+            'debtorAccountIBAN' => 'FI1350001540000056',
+            'debtorAgentBIC' => 'PSSTFRPPMON',
+        ]);
+        $credit->addTransfer('firstPayment', [
+            'amount' => 500,
+            'creditorIban' => 'FI1350001540000056',
+            'creditorBic' => 'OKOYFIHH',
+            'creditorName' => 'Their Company',
+            'remittanceInformation' => 'Purpose of this credit',
+        ]);
+
+        // Capture saveXML() immediately — both calls return the same underlying
+        // DOMDocument instance, so capturing *after* the second call would mask
+        // the bug by comparing the final state to itself.
+        $firstXml = $credit->asDOC()->saveXML();
+        $secondXml = $credit->asDOC()->saveXML();
+
+        $this->assertSame(
+            $firstXml,
+            $secondXml,
+            'asDOC() must produce identical output across repeated calls'
+        );
+    }
+
+    public function testMixedAsXmlAsDocIsIdempotent(): void
+    {
+        $credit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me', 'pain.001.001.09');
+        $credit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'debtorName' => 'My Company',
+            'debtorAccountIBAN' => 'FI1350001540000056',
+            'debtorAgentBIC' => 'PSSTFRPPMON',
+        ]);
+        $credit->addTransfer('firstPayment', [
+            'amount' => 500,
+            'creditorIban' => 'FI1350001540000056',
+            'creditorBic' => 'OKOYFIHH',
+            'creditorName' => 'Their Company',
+            'remittanceInformation' => 'Purpose of this credit',
+        ]);
+
+        $xmlFromAsXml = $credit->asXML();
+        $xmlFromAsDoc = $credit->asDOC()->saveXML();
+
+        $this->assertSame($xmlFromAsXml, $xmlFromAsDoc, 'asXML() and asDOC() must agree on output');
+    }
+
+    public function testDirectDebitAsXmlIsIdempotent(): void
+    {
+        $directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me', 'pain.008.001.02');
+        $directDebit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'creditorName' => 'My Company',
+            'creditorAccountIBAN' => 'FI1350001540000056',
+            'creditorAgentBIC' => 'PSSTFRPPMON',
+            'seqType' => PaymentInformation::S_ONEOFF,
+            'creditorId' => 'DE21WVM1234567890',
+        ]);
+        $directDebit->addTransfer('firstPayment', [
+            'amount' => 500,
+            'debtorIban' => 'FI1350001540000056',
+            'debtorBic' => 'OKOYFIHH',
+            'debtorName' => 'Their Company',
+            'debtorMandate' => 'AB12345',
+            'debtorMandateSignDate' => '13.10.2012',
+            'remittanceInformation' => 'Purpose of this direct debit',
+        ]);
+
+        $firstXml = $directDebit->asXML();
+        $secondXml = $directDebit->asXML();
+
+        $this->assertSame($firstXml, $secondXml, 'Direct debit asXML() must be idempotent');
+
+        $xpath = $this->xpath($secondXml, 'pain.008.001.02');
+        $this->assertSame('1', $xpath->evaluate('string(//sepa:GrpHdr/sepa:NbOfTxs)'));
+        $this->assertSame('5.00', $xpath->evaluate('string(//sepa:GrpHdr/sepa:CtrlSum)'));
+        $this->assertSame(1, $xpath->query('//sepa:CstmrDrctDbtInitn')->length);
+        $this->assertSame(1, $xpath->query('//sepa:PmtInf')->length);
+    }
+
+    private function xpath(string $xml, string $painFormat): \DOMXPath
+    {
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($xml);
+        $xpath = new \DOMXPath($doc);
+        $xpath->registerNamespace('sepa', sprintf('urn:iso:std:iso:20022:tech:xsd:%s', $painFormat));
+
+        return $xpath;
+    }
+}


### PR DESCRIPTION
# Changelog

## Changed
- Made `asXML()` methods idempotent. Whether the document has been rendered. Guards against re-flushing payments into the transfer file (which would double the `NbOfTxs` / `CtrlSum` counters on `GroupHeader` and  duplicate `<PmtInf>` nodes in the DOM)