### PR TITLE
Feature/issue 233 dk compliance

### DIFF
--- a/doc/credit_transfer.md
+++ b/doc/credit_transfer.md
@@ -88,3 +88,20 @@ $customerCredit->addTransfer('firstPayment', array(
 // Retrieve the resulting XML
 $customerCredit->asXML();
 ```
+
+Additional Features
+--------------------------------------
+- `BaseDomBuilder::setOmitGroupHeaderControlSum(bool)` — suppresses       `<CtrlSum>` inside `<GrpHdr>`. Required by the German DK pain.001.001.03 profile, which forbids CtrlSum at group-header level.
+- `BaseDomBuilder::setOmitAgentElementIfBicMissing(bool)` — omits the whole `<CdtrAgt>`/`<DbtrAgt>` wrapper when the corresponding BIC is missing, instead of emitting `<Othr><Id>NOTPROVIDED</Id></Othr>`. Applied at all four agent-element call sites (SCT and SDD, payment and transfer levels).
+- Passthrough methods on `BaseCustomerTransferFileFacade` so facade users can set both flags without reaching into the builder.
+Both flags default to `false`; existing callers are unaffected. To use set the flags on the facade instance before adding transfers:
+- 
+```php
+use Digitick\Sepa\TransferFile\Factory\TransferFileFacadeFactory;
+
+// Returns a CustomerCreditFacade
+$customerCredit = TransferFileFacadeFactory::createCustomerCredit('test123', 'Me');
+
+$customerCredit->setOmitAgentElementIfBicMissing(true);
+$customerCredit->setOmitAgentElementIfBicMissing(true);
+```

--- a/doc/direct_debit.md
+++ b/doc/direct_debit.md
@@ -190,3 +190,28 @@ $directDebit->addTransfer('firstPayment', [
     'floorNumber'       => '13'
 ]);
 ````
+
+
+Additional Features
+--------------------------------------
+- `BaseDomBuilder::setOmitGroupHeaderControlSum(bool)` — suppresses       `<CtrlSum>` inside `<GrpHdr>`. Required by the German DK pain.001.001.03 profile, which forbids CtrlSum at group-header level.
+- `BaseDomBuilder::setOmitAgentElementIfBicMissing(bool)` — omits the whole `<CdtrAgt>`/`<DbtrAgt>` wrapper when the corresponding BIC is missing, instead of emitting `<Othr><Id>NOTPROVIDED</Id></Othr>`. Applied at all four agent-element call sites (SCT and SDD, payment and transfer levels).
+- Passthrough methods on `BaseCustomerTransferFileFacade` so facade users can set both flags without reaching into the builder.
+
+Both flags default to `false`; existing callers are unaffected.
+
+To use set the flags on the facade instance before adding transfers:
+```php
+use Digitick\Sepa\TransferFile\Factory\TransferFileFacadeFactory;
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\GroupHeader;
+
+//Set the custom header (Spanish banks example) information
+$header = new GroupHeader(date('Y-m-d-H-i-s'), 'Me');
+$header->setInitiatingPartyId('DE21WVM1234567890');
+
+$directDebit = TransferFileFacadeFactory::createDirectDebitWithGroupHeader($header, 'pain.008.001.09');
+
+$directDebit->setOmitAgentElementIfBicMissing(true);
+$directDebit->setOmitAgentElementIfBicMissing(true);
+```

--- a/src/DomBuilder/BaseDomBuilder.php
+++ b/src/DomBuilder/BaseDomBuilder.php
@@ -50,14 +50,14 @@ abstract class BaseDomBuilder implements DomBuilderInterface
      * German DK pain.001.001.03 profile, which forbids CtrlSum at the
      * group-header level.
      */
-    private bool $omitGroupHeaderControlSum = false;
+    private $omitGroupHeaderControlSum = false;
 
     /**
      * When true, the <CdtrAgt>/<DbtrAgt> wrapper is omitted entirely when
      * the corresponding BIC is missing, instead of emitting the
      * <Othr><Id>NOTPROVIDED</Id></Othr> fallback.
      */
-    private bool $omitAgentElementIfBicMissing = false;
+    private $omitAgentElementIfBicMissing = false;
 
     /**
      * @param string $painFormat

--- a/src/DomBuilder/BaseDomBuilder.php
+++ b/src/DomBuilder/BaseDomBuilder.php
@@ -46,6 +46,20 @@ abstract class BaseDomBuilder implements DomBuilderInterface
     protected $messageFormat = null;
 
     /**
+     * When true, <CtrlSum> is suppressed inside <GrpHdr>. Required by the
+     * German DK pain.001.001.03 profile, which forbids CtrlSum at the
+     * group-header level.
+     */
+    private bool $omitGroupHeaderControlSum = false;
+
+    /**
+     * When true, the <CdtrAgt>/<DbtrAgt> wrapper is omitted entirely when
+     * the corresponding BIC is missing, instead of emitting the
+     * <Othr><Id>NOTPROVIDED</Id></Othr> fallback.
+     */
+    private bool $omitAgentElementIfBicMissing = false;
+
+    /**
      * @param string $painFormat
      * @param bool $withSchemaLocation define if xsi:schemaLocation attribute is added to root
      * @throws \DOMException
@@ -105,6 +119,26 @@ abstract class BaseDomBuilder implements DomBuilderInterface
         return $this->doc->saveXML();
     }
 
+    public function setOmitGroupHeaderControlSum(bool $omit): void
+    {
+        $this->omitGroupHeaderControlSum = $omit;
+    }
+
+    public function setOmitAgentElementIfBicMissing(bool $omit): void
+    {
+        $this->omitAgentElementIfBicMissing = $omit;
+    }
+
+    /**
+     * True when the caller (visitPaymentInformation / visitTransferInformation)
+     * should skip the <CdtrAgt>/<DbtrAgt> wrapper altogether for a missing BIC
+     * — as opposed to emitting the NOTPROVIDED fallback.
+     */
+    protected function shouldOmitAgentElementFor(?string $bic): bool
+    {
+        return $bic === null && $this->omitAgentElementIfBicMissing;
+    }
+
     public function asDoc(): DomDocument
     {
         return $this->doc;
@@ -132,9 +166,11 @@ abstract class BaseDomBuilder implements DomBuilderInterface
         );
         $groupHeaderTag->appendChild($creationDateTime);
         $groupHeaderTag->appendChild($this->createElement('NbOfTxs', (string) $groupHeader->getNumberOfTransactions()));
-        $groupHeaderTag->appendChild(
-            $this->createElement('CtrlSum', $this->intToCurrency($groupHeader->getControlSumCents()))
-        );
+        if (!$this->omitGroupHeaderControlSum) {
+            $groupHeaderTag->appendChild(
+                $this->createElement('CtrlSum', $this->intToCurrency($groupHeader->getControlSumCents()))
+            );
+        }
 
         $initiatingParty = $this->createElement('InitgPty');
         $initiatingPartyName = $this->createElement('Nm', $groupHeader->getInitiatingPartyName());

--- a/src/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -134,10 +134,12 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         }
         $this->currentPayment->appendChild($debtorAccount);
 
-        $debtorAgent = $this->createElement('DbtrAgt');
-        $financialInstitutionId = $this->getFinancialInstitutionElement($paymentInformation->getOriginAgentBIC());
-        $debtorAgent->appendChild($financialInstitutionId);
-        $this->currentPayment->appendChild($debtorAgent);
+        $originBic = $paymentInformation->getOriginAgentBIC();
+        if (!$this->shouldOmitAgentElementFor($originBic)) {
+            $debtorAgent = $this->createElement('DbtrAgt');
+            $debtorAgent->appendChild($this->getFinancialInstitutionElement($originBic));
+            $this->currentPayment->appendChild($debtorAgent);
+        }
 
         $this->currentPayment->appendChild($this->createElement('ChrgBr', 'SLEV'));
         $this->currentTransfer->appendChild($this->currentPayment);
@@ -172,9 +174,12 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         $CdtTrfTxInf->appendChild($amount);
 
         //Creditor Agent 2.77
-        $creditorAgent = $this->createElement('CdtrAgt');
-        $creditorAgent->appendChild($this->getFinancialInstitutionElement($transactionInformation->getBic()));
-        $CdtTrfTxInf->appendChild($creditorAgent);
+        $creditorBic = $transactionInformation->getBic();
+        if (!$this->shouldOmitAgentElementFor($creditorBic)) {
+            $creditorAgent = $this->createElement('CdtrAgt');
+            $creditorAgent->appendChild($this->getFinancialInstitutionElement($creditorBic));
+            $CdtTrfTxInf->appendChild($creditorAgent);
+        }
 
 
         // Creditor 2.79

--- a/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -100,9 +100,12 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
         $this->currentPayment->appendChild($creditorAccount);
 
         // <CdtrAgt>
-        $creditorAgent = $this->createElement('CdtrAgt');
-        $creditorAgent->appendChild($this->getFinancialInstitutionElement($paymentInformation->getOriginAgentBIC()));
-        $this->currentPayment->appendChild($creditorAgent);
+        $originBic = $paymentInformation->getOriginAgentBIC();
+        if (!$this->shouldOmitAgentElementFor($originBic)) {
+            $creditorAgent = $this->createElement('CdtrAgt');
+            $creditorAgent->appendChild($this->getFinancialInstitutionElement($originBic));
+            $this->currentPayment->appendChild($creditorAgent);
+        }
 
         $this->currentPayment->appendChild($this->createElement('ChrgBr', 'SLEV'));
 
@@ -176,9 +179,12 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
 
         // TODO add the possibility to add CreditorSchemeId on transfer level
 
-        $debtorAgent = $this->createElement('DbtrAgt');
-        $debtorAgent->appendChild($this->getFinancialInstitutionElement($transactionInformation->getBic()));
-        $directDebitTransactionInformation->appendChild($debtorAgent);
+        $debtorBic = $transactionInformation->getBic();
+        if (!$this->shouldOmitAgentElementFor($debtorBic)) {
+            $debtorAgent = $this->createElement('DbtrAgt');
+            $debtorAgent->appendChild($this->getFinancialInstitutionElement($debtorBic));
+            $directDebitTransactionInformation->appendChild($debtorAgent);
+        }
 
         $debtor = $this->createElement('Dbtr');
         $debtor->appendChild($this->createElement('Nm', $transactionInformation->getDebitorName()));

--- a/src/TransferFile/Facade/BaseCustomerTransferFileFacade.php
+++ b/src/TransferFile/Facade/BaseCustomerTransferFileFacade.php
@@ -62,6 +62,24 @@ abstract class BaseCustomerTransferFileFacade implements CustomerTransferFileFac
         return $this->payments[$paymentName] ?? null;
     }
 
+    /**
+     * Suppress <CtrlSum> inside <GrpHdr>. Required by the German DK
+     * pain.001.001.03 profile.
+     */
+    public function setOmitGroupHeaderControlSum(bool $omit): void
+    {
+        $this->domBuilder->setOmitGroupHeaderControlSum($omit);
+    }
+
+    /**
+     * Omit the <CdtrAgt>/<DbtrAgt> wrapper altogether when the corresponding
+     * BIC is missing, instead of emitting <Othr><Id>NOTPROVIDED</Id></Othr>.
+     */
+    public function setOmitAgentElementIfBicMissing(bool $omit): void
+    {
+        $this->domBuilder->setOmitAgentElementIfBicMissing($omit);
+    }
+
     public function asXML(): string
     {
         foreach ($this->payments as $payment) {

--- a/tests/Unit/DomBuilder/DkComplianceTest.php
+++ b/tests/Unit/DomBuilder/DkComplianceTest.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace Digitick\Sepa\Tests\Unit\DomBuilder;
+
+use Digitick\Sepa\DomBuilder\CustomerCreditTransferDomBuilder;
+use Digitick\Sepa\DomBuilder\CustomerDirectDebitTransferDomBuilder;
+use Digitick\Sepa\GroupHeader;
+use Digitick\Sepa\PaymentInformation;
+use Digitick\Sepa\TransferFile\CustomerCreditTransferFile;
+use Digitick\Sepa\TransferFile\CustomerDirectDebitTransferFile;
+use Digitick\Sepa\TransferFile\Factory\TransferFileFacadeFactory;
+use Digitick\Sepa\TransferInformation\CustomerCreditTransferInformation;
+use Digitick\Sepa\TransferInformation\CustomerDirectDebitTransferInformation;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the opt-in compliance flags for environments like the German DK
+ * specification (issue #233):
+ *
+ *  - setOmitGroupHeaderControlSum(true) suppresses <CtrlSum> under <GrpHdr>.
+ *    DK forbids CtrlSum at the group-header level; it must only appear
+ *    under PmtInf.
+ *
+ *  - setOmitAgentElementIfBicMissing(true) omits the <CdtrAgt>/<DbtrAgt>
+ *    wrapper when no BIC is available, instead of emitting the
+ *    <Othr><Id>NOTPROVIDED</Id></Othr> fallback that DK rejects.
+ *
+ * The defaults remain the pre-existing behaviour so that this change is
+ * fully backwards compatible. Regression coverage for the defaults lives
+ * in FinancialInstitutionElementTest.
+ */
+class DkComplianceTest extends TestCase
+{
+    private const SCT_PAIN = 'pain.001.001.03';
+    private const SDD_PAIN = 'pain.008.001.02';
+
+    // ---------- CtrlSum on GroupHeader --------------------------------------
+
+    public function testGroupHeaderCtrlSumPresentByDefault(): void
+    {
+        $xpath = $this->renderSct(function ($builder) {
+            // no flag
+        });
+
+        $this->assertSame(1, $xpath->query('//ns:GrpHdr/ns:CtrlSum')->length);
+    }
+
+    public function testSctOmitsGrpHdrCtrlSumWhenFlagSet(): void
+    {
+        $xpath = $this->renderSct(function (CustomerCreditTransferDomBuilder $builder) {
+            $builder->setOmitGroupHeaderControlSum(true);
+        });
+
+        $this->assertSame(0, $xpath->query('//ns:GrpHdr/ns:CtrlSum')->length);
+        // PmtInf/CtrlSum must still appear — CtrlSum is valid there.
+        $this->assertSame(1, $xpath->query('//ns:PmtInf/ns:CtrlSum')->length);
+    }
+
+    public function testSddOmitsGrpHdrCtrlSumWhenFlagSet(): void
+    {
+        $xpath = $this->renderSdd(function (CustomerDirectDebitTransferDomBuilder $builder) {
+            $builder->setOmitGroupHeaderControlSum(true);
+        });
+
+        $this->assertSame(0, $xpath->query('//ns:GrpHdr/ns:CtrlSum')->length);
+        $this->assertSame(1, $xpath->query('//ns:PmtInf/ns:CtrlSum')->length);
+    }
+
+    // ---------- Agent element on missing BIC --------------------------------
+
+    public function testSctOmitsCdtrAgtAtTransactionLevelWhenBicMissingAndFlagSet(): void
+    {
+        $xpath = $this->renderSct(function (CustomerCreditTransferDomBuilder $builder) {
+            $builder->setOmitAgentElementIfBicMissing(true);
+        }, /* transferBic */ null);
+
+        $this->assertSame(0, $xpath->query('//ns:CdtTrfTxInf/ns:CdtrAgt')->length);
+    }
+
+    public function testSctOmitsDbtrAgtAtPaymentLevelWhenBicMissingAndFlagSet(): void
+    {
+        $xpath = $this->renderSct(function (CustomerCreditTransferDomBuilder $builder) {
+            $builder->setOmitAgentElementIfBicMissing(true);
+        }, /* transferBic */ 'DEUTDEFF', /* originBic */ null);
+
+        $this->assertSame(0, $xpath->query('//ns:PmtInf/ns:DbtrAgt')->length);
+    }
+
+    public function testSctPreservesAgentElementsWhenBicPresentAndFlagSet(): void
+    {
+        $xpath = $this->renderSct(function (CustomerCreditTransferDomBuilder $builder) {
+            $builder->setOmitAgentElementIfBicMissing(true);
+        }, /* transferBic */ 'DEUTDEFF', /* originBic */ 'DEUTDEFF');
+
+        // Flag is on but BICs are present — agent wrappers must remain.
+        $this->assertSame(1, $xpath->query('//ns:CdtTrfTxInf/ns:CdtrAgt')->length);
+        $this->assertSame(1, $xpath->query('//ns:PmtInf/ns:DbtrAgt')->length);
+    }
+
+    public function testSctEmitsNotProvidedWhenBicMissingAndFlagNotSet(): void
+    {
+        // Defaults must not change: existing NOTPROVIDED behaviour stays.
+        $xpath = $this->renderSct(function ($builder) {
+            // no flag
+        }, /* transferBic */ null);
+
+        $this->assertSame(1, $xpath->query('//ns:CdtTrfTxInf/ns:CdtrAgt')->length);
+        $this->assertSame(
+            'NOTPROVIDED',
+            $xpath->evaluate('string(//ns:CdtTrfTxInf/ns:CdtrAgt/ns:FinInstnId/ns:Othr/ns:Id)')
+        );
+    }
+
+    public function testSddOmitsDbtrAgtAtTransactionLevelWhenBicMissingAndFlagSet(): void
+    {
+        $xpath = $this->renderSdd(function (CustomerDirectDebitTransferDomBuilder $builder) {
+            $builder->setOmitAgentElementIfBicMissing(true);
+        }, /* transferBic */ null);
+
+        $this->assertSame(0, $xpath->query('//ns:DrctDbtTxInf/ns:DbtrAgt')->length);
+    }
+
+    public function testSddOmitsCdtrAgtAtPaymentLevelWhenBicMissingAndFlagSet(): void
+    {
+        $xpath = $this->renderSdd(function (CustomerDirectDebitTransferDomBuilder $builder) {
+            $builder->setOmitAgentElementIfBicMissing(true);
+        }, /* transferBic */ 'DEUTDEFF', /* originBic */ null);
+
+        $this->assertSame(0, $xpath->query('//ns:PmtInf/ns:CdtrAgt')->length);
+    }
+
+    // ---------- Integration: full DK-compliant pain.001.001.03 --------------
+
+    public function testDkCompliantPain00100103FileHasExpectedStructure(): void
+    {
+        // DK intentionally diverges from the base ISO pain.001.001.03 XSD:
+        //  - PmtInf/DbtrAgt is mandatory in the ISO XSD but DK requires it
+        //    absent when no BIC is known, and validates via its own stricter
+        //    profile schema rather than the base ISO one.
+        // So we assert the structural DK requirements here rather than
+        // base-XSD validation, which would necessarily fail for this shape.
+        $builder = new CustomerCreditTransferDomBuilder(self::SCT_PAIN);
+        $builder->setOmitGroupHeaderControlSum(true);
+        $builder->setOmitAgentElementIfBicMissing(true);
+
+        $groupHeader = new GroupHeader('DK-MSG-42', 'DK Corp');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = new PaymentInformation('P1', 'DE88500105173441451911', null, 'Origin');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerCreditTransferInformation(100, 'DE40500105174181777145', 'Bob');
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($builder->asXml());
+        $xpath = new \DOMXPath($doc);
+        $xpath->registerNamespace('ns', 'urn:iso:std:iso:20022:tech:xsd:' . self::SCT_PAIN);
+
+        // DK-forbidden elements: absent
+        $this->assertSame(0, $xpath->query('//ns:GrpHdr/ns:CtrlSum')->length);
+        $this->assertSame(0, $xpath->query('//ns:PmtInf/ns:DbtrAgt')->length);
+        $this->assertSame(0, $xpath->query('//ns:CdtTrfTxInf/ns:CdtrAgt')->length);
+
+        // Required elements still present
+        $this->assertSame(1, $xpath->query('//ns:GrpHdr/ns:MsgId')->length);
+        $this->assertSame(1, $xpath->query('//ns:GrpHdr/ns:NbOfTxs')->length);
+        $this->assertSame(1, $xpath->query('//ns:PmtInf/ns:CtrlSum')->length);
+    }
+
+    // ---------- Facade passthrough ------------------------------------------
+
+    public function testFacadeExposesOmitGroupHeaderControlSum(): void
+    {
+        $facade = TransferFileFacadeFactory::createCustomerCredit('MSG', 'Me', self::SCT_PAIN);
+        $facade->setOmitGroupHeaderControlSum(true);
+        $facade->addPaymentInfo('p', [
+            'id' => 'p',
+            'debtorName' => 'Me',
+            'debtorAccountIBAN' => 'DE88500105173441451911',
+            'debtorAgentBIC' => 'DEUTDEFF',
+        ]);
+        $facade->addTransfer('p', [
+            'amount' => 100,
+            'creditorIban' => 'DE40500105174181777145',
+            'creditorBic' => 'DEUTDEFF',
+            'creditorName' => 'Bob',
+            'remittanceInformation' => 'x',
+        ]);
+
+        $xml = $facade->asXML();
+        $this->assertStringNotContainsString('<CtrlSum>', substr($xml, 0, strpos($xml, '<PmtInf>')));
+    }
+
+    public function testFacadeExposesOmitAgentElementIfBicMissing(): void
+    {
+        $facade = TransferFileFacadeFactory::createCustomerCredit('MSG', 'Me', self::SCT_PAIN);
+        $facade->setOmitAgentElementIfBicMissing(true);
+        $facade->addPaymentInfo('p', [
+            'id' => 'p',
+            'debtorName' => 'Me',
+            'debtorAccountIBAN' => 'DE88500105173441451911',
+            // no debtorAgentBIC
+        ]);
+        $facade->addTransfer('p', [
+            'amount' => 100,
+            'creditorIban' => 'DE40500105174181777145',
+            'creditorName' => 'Bob',
+            // no creditorBic
+            'remittanceInformation' => 'x',
+        ]);
+
+        $xml = $facade->asXML();
+        $this->assertStringNotContainsString('<DbtrAgt>', $xml);
+        $this->assertStringNotContainsString('<CdtrAgt>', $xml);
+    }
+
+    // ---------- Helpers -----------------------------------------------------
+
+    /**
+     * @param callable(CustomerCreditTransferDomBuilder): void $configureBuilder
+     */
+    private function renderSct(
+        callable $configureBuilder,
+        ?string $transferBic = 'DEUTDEFF',
+        ?string $originBic = 'DEUTDEFFXXX'
+    ): \DOMXPath {
+        $builder = new CustomerCreditTransferDomBuilder(self::SCT_PAIN);
+        $configureBuilder($builder);
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerCreditTransferFile($groupHeader);
+        $payment = new PaymentInformation('P1', 'DE88500105173441451911', $originBic, 'Origin');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerCreditTransferInformation(100, 'DE40500105174181777145', 'Bob');
+        if ($transferBic !== null) {
+            $transfer->setBic($transferBic);
+        }
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        return $this->xpath($builder->asXml(), self::SCT_PAIN);
+    }
+
+    /**
+     * @param callable(CustomerDirectDebitTransferDomBuilder): void $configureBuilder
+     */
+    private function renderSdd(
+        callable $configureBuilder,
+        ?string $transferBic = 'DEUTDEFF',
+        ?string $originBic = 'DEUTDEFFXXX'
+    ): \DOMXPath {
+        $builder = new CustomerDirectDebitTransferDomBuilder(self::SDD_PAIN);
+        $configureBuilder($builder);
+
+        $groupHeader = new GroupHeader('MSG', 'Init');
+        $transferFile = new CustomerDirectDebitTransferFile($groupHeader);
+        $payment = new PaymentInformation('P1', 'DE88500105173441451911', $originBic, 'Origin');
+        $payment->setSequenceType(PaymentInformation::S_ONEOFF);
+        $payment->setCreditorId('DE67ZZZ00000123456');
+        $transferFile->addPaymentInformation($payment);
+
+        $transfer = new CustomerDirectDebitTransferInformation(100, 'DE40500105174181777145', 'Bob');
+        $transfer->setMandateId('M1');
+        $transfer->setMandateSignDate(new \DateTimeImmutable('2022-05-15'));
+        if ($transferBic !== null) {
+            $transfer->setBic($transferBic);
+        }
+        $payment->addTransfer($transfer);
+
+        $transferFile->accept($builder);
+
+        return $this->xpath($builder->asXml(), self::SDD_PAIN);
+    }
+
+    private function xpath(string $xml, string $painFormat): \DOMXPath
+    {
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $doc->loadXML($xml);
+        $xpath = new \DOMXPath($doc);
+        $xpath->registerNamespace('ns', sprintf('urn:iso:std:iso:20022:tech:xsd:%s', $painFormat));
+        return $xpath;
+    }
+}


### PR DESCRIPTION
# Changelog

## Added
- Add opt-in DK compliance flags
-- `BaseDomBuilder::setOmitGroupHeaderControlSum(bool)` — suppresses       `<CtrlSum>` inside `<GrpHdr>`. Required by the German DK pain.001.001.03 profile, which forbids CtrlSum at group-header level.
-- `BaseDomBuilder::setOmitAgentElementIfBicMissing(bool)` — omits the whole `<CdtrAgt>`/`<DbtrAgt>` wrapper when the corresponding BIC is missing, instead of emitting `<Othr><Id>NOTPROVIDED</Id></Othr>`. Applied at all four agent-element call sites (SCT and SDD, payment and transfer levels).
-- Passthrough methods on `BaseCustomerTransferFileFacade` so facade users can set both flags without reaching into the builder.
-- `tests/Unit/DomBuilder/DkComplianceTest.php` — 12 tests covering defaults preserved, both flags at both levels on both SCT and SDD, the "flag on but BIC present" no-op case, and the facade passthroughs.

Both flags default to `false`; existing callers are unaffected.  Regression coverage for the unchanged defaults lives in    `FinancialInstitutionElementTest`.
    
Fixes #233 and #231