### PR TITLE
Readd `<PmtTpInf>` with necessary conditions, which was dropped in v3.0

### DIFF
--- a/src/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -164,6 +164,33 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
         }
         $CdtTrfTxInf->appendChild($PmtId);
 
+        if ($transactionInformation->getServiceLevelCode() || $transactionInformation->getLocalInstrumentCode() || $transactionInformation->getLocalInstrumentProprietary() || $transactionInformation->getCategoryPurposeCode()) {
+            $PmtTpInf = $this->createElement('PmtTpInf');
+
+            if ($transactionInformation->getServiceLevelCode()) {
+                $SvcLvl = $this->createElement('SvcLvl');
+                $SvcLvl->appendChild($this->createElement('Cd', $transactionInformation->getServiceLevelCode()));
+                $PmtTpInf->appendChild($SvcLvl);
+            }
+
+            if ($transactionInformation->getLocalInstrumentCode() || $transactionInformation->getLocalInstrumentProprietary()) {
+                $localInstrument = $this->createElement('LclInstrm');
+                if ($transactionInformation->getLocalInstrumentCode()) {
+                    $localInstrument->appendChild($this->createElement('Cd', $transactionInformation->getLocalInstrumentCode()));
+                } else if ($transactionInformation->getLocalInstrumentProprietary()) {
+                    $localInstrument->appendChild($this->createElement('Prtry', $transactionInformation->getLocalInstrumentProprietary()));
+                }
+                $PmtTpInf->appendChild($localInstrument);
+            }
+
+            if ($transactionInformation->getCategoryPurposeCode()) {
+                $CtgyPurp = $this->createElement('CtgyPurp');
+                $CtgyPurp->appendChild($this->createElement('Cd', $transactionInformation->getCategoryPurposeCode()));
+                $PmtTpInf->appendChild($CtgyPurp);
+            }
+            $CdtTrfTxInf->appendChild($PmtTpInf);
+        }
+
         // Amount 2.42
         $amount = $this->createElement('Amt');
         $instructedAmount = $this->createElement(

--- a/src/DomBuilder/CustomerCreditTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerCreditTransferDomBuilder.php
@@ -177,7 +177,7 @@ class CustomerCreditTransferDomBuilder extends BaseDomBuilder
                 $localInstrument = $this->createElement('LclInstrm');
                 if ($transactionInformation->getLocalInstrumentCode()) {
                     $localInstrument->appendChild($this->createElement('Cd', $transactionInformation->getLocalInstrumentCode()));
-                } else if ($transactionInformation->getLocalInstrumentProprietary()) {
+                } elseif ($transactionInformation->getLocalInstrumentProprietary()) {
                     $localInstrument->appendChild($this->createElement('Prtry', $transactionInformation->getLocalInstrumentProprietary()));
                 }
                 $PmtTpInf->appendChild($localInstrument);

--- a/src/TransferInformation/BaseTransferInformation.php
+++ b/src/TransferInformation/BaseTransferInformation.php
@@ -24,6 +24,7 @@
 namespace Digitick\Sepa\TransferInformation;
 
 use Digitick\Sepa\DomBuilder\DomBuilderInterface;
+use Digitick\Sepa\Exception\InvalidArgumentException;
 use Digitick\Sepa\Util\Sanitizer;
 
 class BaseTransferInformation implements TransferInformationInterface
@@ -58,6 +59,26 @@ class BaseTransferInformation implements TransferInformationInterface
      * @var string|null
      */
     protected $instructionId;
+
+    /**
+     * @var string|null Service Level code
+     */
+    protected $serviceLevelCode;
+
+    /**
+     * @var string|null Local service proprietary code
+     */
+    protected $localInstrumentProprietary;
+
+    /**
+     * @var string|null Local service instrument code
+     */
+    protected $localInstrumentCode;
+
+    /**
+     * @var string|null
+     */
+    protected $categoryPurposeCode;
 
     /**
      * @var string
@@ -236,6 +257,63 @@ class BaseTransferInformation implements TransferInformationInterface
     public function getInstructionId(): ?string
     {
         return $this->instructionId;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function setServiceLevelCode(string $serviceLevelCode): void
+    {
+        $serviceLevelCode = strtoupper($serviceLevelCode);
+        if (!in_array($serviceLevelCode, ['SEPA'])) {
+            throw new InvalidArgumentException("Invalid Local Instrument Code: $serviceLevelCode");
+        }
+        $this->serviceLevelCode = $serviceLevelCode;
+    }
+
+    public function getServiceLevelCode(): ?string
+    {
+        return $this->serviceLevelCode;
+    }
+
+    /**
+     * @param string $localInstrumentProprietary
+     */
+    public function setLocalInstrumentProprietary(string $localInstrumentProprietary): void
+    {
+        $this->localInstrumentProprietary = $localInstrumentProprietary;
+    }
+
+    public function getLocalInstrumentProprietary(): ?string
+    {
+        return $this->localInstrumentProprietary;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function setLocalInstrumentCode(string $localInstrumentCode): void
+    {
+        $localInstrumentCode = strtoupper($localInstrumentCode);
+        if (!in_array($localInstrumentCode, ['B2B', 'CORE', 'COR1'])) {
+            throw new InvalidArgumentException("Invalid Local Instrument Code: $localInstrumentCode");
+        }
+        $this->localInstrumentCode = $localInstrumentCode;
+    }
+
+    public function getLocalInstrumentCode(): ?string
+    {
+        return $this->localInstrumentCode;
+    }
+
+    public function setCategoryPurposeCode(string $categoryPurposeCode): void
+    {
+        $this->categoryPurposeCode = $categoryPurposeCode;
+    }
+
+    public function getCategoryPurposeCode(): ?string
+    {
+        return $this->categoryPurposeCode;
     }
 
     public function getIban(): string

--- a/src/TransferInformation/TransferInformationInterface.php
+++ b/src/TransferInformation/TransferInformationInterface.php
@@ -37,7 +37,15 @@ interface TransferInformationInterface
 
     public function getInstructionId(): ?string;
 
+    public function getServiceLevelCode(): ?string;
+
+    public function getLocalInstrumentProprietary(): ?string;
+
+    public function getLocalInstrumentCode(): ?string;
+
     public function getCreditorReferenceType(): ?string;
+
+    public function getCategoryPurposeCode(): ?string;
 
     public function getCreditorReference(): ?string;
 

--- a/tests/Functional/CustomerCreditValidationPain00100103Test.php
+++ b/tests/Functional/CustomerCreditValidationPain00100103Test.php
@@ -143,7 +143,7 @@ class CustomerCreditValidationPain00100103Test extends TestCase
         if (isset($scenario['transactionServiceLevelCode'])) {
             $transactionServiceLevelCodeProprietary = $xpathDoc->query('//sepa:CdtTrfTxInf/sepa:PmtTpInf/sepa:SvcLvl/sepa:Cd');
             $this->assertEquals($scenario['transactionServiceLevelCode'], $transactionServiceLevelCodeProprietary->item(0)->textContent);
-        } else if (!isset($scenario['transactionCategoryPurposeCode']) && !isset($scenario['transactionLocalInstrumentProprietary']) && !isset($scenario['transactionLocalInstrumentCode'])) {
+        } elseif (!isset($scenario['transactionCategoryPurposeCode']) && !isset($scenario['transactionLocalInstrumentProprietary']) && !isset($scenario['transactionLocalInstrumentCode'])) {
             $transactionServiceProprietary = $xpathDoc->query('//sepa:CdtTrfTxInf/sepa:PmtTpInf');
             $this->assertSame(0, $transactionServiceProprietary->length);
         }

--- a/tests/Functional/CustomerCreditValidationPain00100103Test.php
+++ b/tests/Functional/CustomerCreditValidationPain00100103Test.php
@@ -80,7 +80,17 @@ class CustomerCreditValidationPain00100103Test extends TestCase
         $transfer->setRemittanceInformation('Transaction Description');
         $transfer->setEndToEndIdentification(uniqid());
         $transfer->setInstructionId(uniqid());
-
+        if (isset($scenario['transactionLocalInstrumentProprietary'])) {
+            $transfer->setLocalInstrumentProprietary($scenario['transactionLocalInstrumentProprietary']);
+        } elseif (isset($scenario['transactionLocalInstrumentCode'])) {
+            $transfer->setLocalInstrumentCode($scenario['transactionLocalInstrumentCode']);
+        }
+        if (isset($scenario['transactionServiceLevelCode'])) {
+            $transfer->setServiceLevelCode($scenario['transactionServiceLevelCode']);
+        }
+        if (isset($scenario['transactionCategoryPurposeCode'])) {
+            $transfer->setCategoryPurposeCode($scenario['transactionCategoryPurposeCode']);
+        }
         $transfer->setStreetName('Straat creditor 1');
         $transfer->setPostCode('9999');
         $transfer->setTownName('XX Plaats creditor');
@@ -116,6 +126,27 @@ class CustomerCreditValidationPain00100103Test extends TestCase
 
         $purposeCode = $xpathDoc->query('//sepa:Purp/sepa:Cd');
         $this->assertEquals('SALA', $purposeCode->item(0)->textContent);
+
+        if (isset($scenario['transactionCategoryPurposeCode'])) {
+            $ctgyPurp = $xpathDoc->query('//sepa:CdtTrfTxInf/sepa:PmtTpInf/sepa:CtgyPurp/sepa:Cd');
+            $this->assertEquals('SUPP', $ctgyPurp->item(0)->textContent);
+        }
+
+        if (isset($scenario['transactionLocalInstrumentProprietary'])) {
+            $transactionLocalInstrumentProprietary = $xpathDoc->query('//sepa:CdtTrfTxInf/sepa:PmtTpInf/sepa:LclInstrm/sepa:Prtry');
+            $this->assertEquals($scenario['transactionLocalInstrumentProprietary'], $transactionLocalInstrumentProprietary->item(0)->textContent);
+        } elseif (isset($scenario['transactionLocalInstrumentCode'])) {
+            $transactionLocalInstrumentCode = $xpathDoc->query('//sepa:CdtTrfTxInf/sepa:PmtTpInf/sepa:LclInstrm/sepa:Cd');
+            $this->assertEquals($scenario['transactionLocalInstrumentCode'], $transactionLocalInstrumentCode->item(0)->textContent);
+        }
+
+        if (isset($scenario['transactionServiceLevelCode'])) {
+            $transactionServiceLevelCodeProprietary = $xpathDoc->query('//sepa:CdtTrfTxInf/sepa:PmtTpInf/sepa:SvcLvl/sepa:Cd');
+            $this->assertEquals($scenario['transactionServiceLevelCode'], $transactionServiceLevelCodeProprietary->item(0)->textContent);
+        } else if (!isset($scenario['transactionCategoryPurposeCode']) && !isset($scenario['transactionLocalInstrumentProprietary']) && !isset($scenario['transactionLocalInstrumentCode'])) {
+            $transactionServiceProprietary = $xpathDoc->query('//sepa:CdtTrfTxInf/sepa:PmtTpInf');
+            $this->assertSame(0, $transactionServiceProprietary->length);
+        }
 
         if (isset($scenario['localInstrumentProprietary'])) {
             $localInstrumentProprietary = $xpathDoc->query('//sepa:PmtInf/sepa:PmtTpInf/sepa:LclInstrm/sepa:Prtry');
@@ -154,9 +185,30 @@ class CustomerCreditValidationPain00100103Test extends TestCase
             ],
             [
                 [
+                    'batchBooking' => true,
+                    'bic' => 'OKOYFIHH',
+                    'transactionCategoryPurposeCode' => 'SUPP',
+                    'transactionLocalInstrumentProprietary' => 'CBIX',
+                    'localInstrumentProprietary' => 'CBI',
+                ],
+            ],
+            [
+                [
                     'batchBooking' => false,
                     'bic' => '',
+                    'transactionCategoryPurposeCode' => 'SUPP',
+                    'transactionLocalInstrumentCode' => 'B2B',
                     'localInstrumentCode' => 'CORE',
+                ],
+            ],
+            [
+                [
+                    'batchBooking' => false,
+                    'bic' => '',
+                    'transactionCategoryPurposeCode' => 'SUPP',
+                    'transactionLocalInstrumentCode' => 'B2B',
+                    'localInstrumentCode' => 'CORE',
+                    'transactionServiceLevelCode' => 'SEPA',
                 ],
             ],
         ];


### PR DESCRIPTION
This brings back support for adding `<PmtTpInf>` on Transaction level for CreditTransfers, which is required in Italy (it was removed in #217).

### Changes
* Reverted all functional changes from PR #217 (`tests/fixtures/*` excluded)
* Added conditions so `<PmtTpInf>` is only included when necessary
* Added a test to ensure `<PmtTpInf>` is only added when needed
* Added an option `setServiceLevelCode` / `getServiceLevelCode` to the `TransferInformationInterface` (in v2.x it was always set to `SEPA` (which is also the only correct value); now it’s optional for future use)

Closes #244