### PR TITLE
Move ramsey/uuid to require-dev (#246)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,13 @@
     },
     "require": {
         "ext-dom": "*",
-        "php": ">=7.2",
-        "ramsey/uuid": "^4.2.3"
+        "php": ">=7.2"
     },
     "require-dev": {
         "ext-xml": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",
+        "ramsey/uuid": "^4.2.3",
         "phpunit/phpunit": "^10.0",
         "rector/rector": "^2.0",
         "phpstan/phpstan": "^2.0",


### PR DESCRIPTION
ramsey/uuid is only used by the test suite to generate and validate UUIDs; the runtime code (BaseTransferInformation::setUUID/getUUID and the DomBuilders) works purely with strings and never references a ramsey type. Keeping it in `require` needlessly propagated the constraint to consumers and could conflict with their own uuid version.

Moving it to require-dev removes that constraint from dependant projects. No public API change; the test suite is unaffected.

Resolves #246 