### PR TITLE
Add creditor postal address support for Direct Debit (pain.008)

### DIFF
--- a/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
+++ b/src/DomBuilder/CustomerDirectDebitTransferDomBuilder.php
@@ -91,6 +91,39 @@ class CustomerDirectDebitTransferDomBuilder extends BaseDomBuilder
         $this->currentPayment->appendChild($this->createElement('ReqdColltnDt', $paymentInformation->getDueDate()));
         $creditor = $this->createElement('Cdtr');
         $creditor->appendChild($this->createElement('Nm', $paymentInformation->getOriginName()));
+
+        // Creditor postal address is supported starting with pain.008 version 2.
+        if ($this->messageFormat->isDirectDebit() && $this->messageFormat->getVersion() >= 2) {
+            $postalAddress = $this->createElement('PstlAdr');
+
+            // Variants 2 and 3 only support Country and AddressLine
+            if (!in_array($this->messageFormat->getVariant(), [2,3], true)) {
+                if (!empty($paymentInformation->getOriginStreetName())) {
+                    $postalAddress->appendChild($this->createElement('StrtNm', $paymentInformation->getOriginStreetName()));
+                }
+
+                if (!empty($paymentInformation->getOriginBuildingNumber())) {
+                    $postalAddress->appendChild($this->createElement('BldgNb', $paymentInformation->getOriginBuildingNumber()));
+                }
+
+                if (!empty($paymentInformation->getOriginPostCode())) {
+                    $postalAddress->appendChild($this->createElement('PstCd', $paymentInformation->getOriginPostCode()));
+                }
+
+                if (!empty($paymentInformation->getOriginTownName())) {
+                    $postalAddress->appendChild($this->createElement('TwnNm', $paymentInformation->getOriginTownName()));
+                }
+            }
+
+            if (!empty($paymentInformation->getOriginCountry())) {
+                $postalAddress->appendChild($this->createElement('Ctry', $paymentInformation->getOriginCountry()));
+            }
+
+            if ($postalAddress->childNodes->length > 0) {
+                $creditor->appendChild($postalAddress);
+            }
+        }
+
         $this->currentPayment->appendChild($creditor);
 
         // <CdtrAcct>

--- a/src/PaymentInformation.php
+++ b/src/PaymentInformation.php
@@ -68,6 +68,41 @@ class PaymentInformation
     public $originName;
 
     /**
+     * Creditor's postal street name, rendered as <Cdtr><PstlAdr><StrtNm>.
+     *
+     * @var string|null
+     */
+    protected $originStreetName;
+
+    /**
+     * Creditor's postal building number, rendered as <Cdtr><PstlAdr><BldgNb>.
+     *
+     * @var string|null
+     */
+    protected $originBuildingNumber;
+
+    /**
+     * Creditor's postal post code, rendered as <Cdtr><PstlAdr><PstCd>.
+     *
+     * @var string|null
+     */
+    protected $originPostCode;
+
+    /**
+     * Creditor's postal town name, rendered as <Cdtr><PstlAdr><TwnNm>.
+     *
+     * @var string|null
+     */
+    protected $originTownName;
+
+    /**
+     * Creditor's postal country, rendered as <Cdtr><PstlAdr><Ctry>.
+     *
+     * @var string|null
+     */
+    protected $originCountry;
+
+    /**
      * Unique identification of an organisation, as assigned by an institution, using an identification scheme.
      *
      * @var string|null
@@ -428,5 +463,110 @@ class PaymentInformation
     public function setDueDateFormat(string $format): void
     {
         $this->dateFormat = $format;
+    }
+
+    /**
+     * Set the creditor's postal street name.
+     *
+     * @param string|null $originStreetName Maximum allowed length is 70 characters.
+     * @return void
+     */
+    public function setOriginStreetName(?string $originStreetName): void
+    {
+        $this->originStreetName = !empty($originStreetName) ? Sanitizer::sanitize($originStreetName) : null;
+    }
+
+    /**
+     * Get the creditor's postal street name.
+     *
+     * @return string|null
+     */
+    public function getOriginStreetName(): ?string
+    {
+        return $this->originStreetName;
+    }
+
+    /**
+     * Set the creditor's postal building number.
+     *
+     * @param string|null $originBuildingNumber Maximum allowed length is 16 characters.
+     * @return void
+     */
+    public function setOriginBuildingNumber(?string $originBuildingNumber): void
+    {
+        $this->originBuildingNumber = !empty($originBuildingNumber) ? Sanitizer::sanitize($originBuildingNumber) : null;
+    }
+
+    /**
+     * Get the creditor's postal building number.
+     *
+     * @return string|null
+     */
+    public function getOriginBuildingNumber(): ?string
+    {
+        return $this->originBuildingNumber;
+    }
+
+    /**
+     * Set the creditor's postal post code.
+     *
+     * @param string|null $originPostCode Maximum allowed length is 16 characters.
+     * @return void
+     */
+    public function setOriginPostCode(?string $originPostCode): void
+    {
+        $this->originPostCode = !empty($originPostCode) ? Sanitizer::sanitize($originPostCode) : null;
+    }
+
+    /**
+     * Get the creditor's postal post code.
+     *
+     * @return string|null
+     */
+    public function getOriginPostCode(): ?string
+    {
+        return $this->originPostCode;
+    }
+
+    /**
+     * Set the creditor's postal town name.
+     *
+     * @param string|null $originTownName Maximum allowed length is 35 characters.
+     * @return void
+     */
+    public function setOriginTownName(?string $originTownName): void
+    {
+        $this->originTownName = !empty($originTownName) ? Sanitizer::sanitize($originTownName) : null;
+    }
+
+    /**
+     * Get the creditor's postal town name.
+     *
+     * @return string|null
+     */
+    public function getOriginTownName(): ?string
+    {
+        return $this->originTownName;
+    }
+
+    /**
+     * Set the creditor's postal country, as an ISO 3166-1 alpha-2 code.
+     *
+     * @param string|null $originCountry
+     * @return void
+     */
+    public function setOriginCountry(?string $originCountry): void
+    {
+        $this->originCountry = $originCountry !== null ? strtoupper($originCountry) : null;
+    }
+
+    /**
+     * Get the creditor's postal country.
+     *
+     * @return string|null
+     */
+    public function getOriginCountry(): ?string
+    {
+        return $this->originCountry;
     }
 }

--- a/src/TransferFile/Facade/CustomerDirectDebitFacade.php
+++ b/src/TransferFile/Facade/CustomerDirectDebitFacade.php
@@ -44,7 +44,12 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
      *     creditorId: string,
      *     localInstrumentCode?: string,
      *     batchBooking?: bool,
-     *     dueDate?: string|DateTimeInterface
+     *     dueDate?: string|DateTimeInterface,
+     *     creditorStreetName?: string|null,
+     *     creditorBuildingNumber?: string|null,
+     *     creditorPostCode?: string|null,
+     *     creditorTownName?: string|null,
+     *     creditorCountry?: string|null
      * } $paymentInformation
      * @return PaymentInformation
      * @throws InvalidArgumentException
@@ -71,6 +76,27 @@ class CustomerDirectDebitFacade extends BaseCustomerTransferFileFacade
         if (isset($paymentInformation['batchBooking'])) {
             $payment->setBatchBooking($paymentInformation['batchBooking']);
         }
+
+        if (isset($paymentInformation['creditorStreetName'])) {
+            $payment->setOriginStreetName($paymentInformation['creditorStreetName']);
+        }
+
+        if (isset($paymentInformation['creditorBuildingNumber'])) {
+            $payment->setOriginBuildingNumber($paymentInformation['creditorBuildingNumber']);
+        }
+
+        if (isset($paymentInformation['creditorPostCode'])) {
+            $payment->setOriginPostCode($paymentInformation['creditorPostCode']);
+        }
+
+        if (isset($paymentInformation['creditorTownName'])) {
+            $payment->setOriginTownName($paymentInformation['creditorTownName']);
+        }
+
+        if (isset($paymentInformation['creditorCountry'])) {
+            $payment->setOriginCountry($paymentInformation['creditorCountry']);
+        }
+
         $this->payments[$paymentName] = $payment;
 
         return $payment;

--- a/tests/Unit/TransferFile/Facade/CustomerDirectDebitFacadeTest.php
+++ b/tests/Unit/TransferFile/Facade/CustomerDirectDebitFacadeTest.php
@@ -352,6 +352,43 @@ class CustomerDirectDebitFacadeTest extends TestCase
         ];
     }
 
+    public function testCreditorPostalAddressIsRendered(): void
+    {
+        $painFormat = 'pain.008.001.09';
+        $directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me', $painFormat);
+
+        $directDebit->addPaymentInfo('firstPayment', [
+            'id' => 'firstPayment',
+            'creditorName' => 'My Company',
+            'creditorAccountIBAN' => 'DE78500105172337771347',
+            'creditorAgentBIC' => 'WELADE3LXXX',
+            'seqType' => PaymentInformation::S_ONEOFF,
+            'creditorId' => 'DE21WVM1234567890',
+            'creditorStreetName' => 'Example Street',
+            'creditorBuildingNumber' => '25',
+            'creditorPostCode' => '8245',
+            'creditorTownName' => 'Feuerthalen',
+            'creditorCountry' => 'CH',
+        ]);
+
+        $directDebit->addTransfer('firstPayment', [
+            'amount' => 1499,
+            'debtorIban' => 'CH6089144731137988786',
+            'debtorBic' => 'CRESCHZZXXX',
+            'debtorName' => 'John Doe',
+            'debtorMandate' => 'AB12345',
+            'debtorMandateSignDate' => '2022-05-23',
+            'remittanceInformation' => 'Purpose of this direct debit',
+        ]);
+
+        $xml = $directDebit->asXML();
+
+        $this->assertStringContainsString('<StrtNm>Example Street</StrtNm>', $xml);
+        $this->assertStringContainsString('<PstCd>8245</PstCd>', $xml);
+        $this->assertStringContainsString('<TwnNm>Feuerthalen</TwnNm>', $xml);
+        $this->assertStringContainsString('<Ctry>CH</Ctry>', $xml);
+    }
+
     public function testAddPaymentInfoThrowsWhenNameAlreadyExists(): void
     {
         $directDebit = TransferFileFacadeFactory::createDirectDebit('test123', 'Me', 'pain.008.001.02');


### PR DESCRIPTION
 CustomerCreditTransferDomBuilder (pain.001) already renders the counterparty's postal address via appendAddressToDomElement(), and the direct debit debtor (\<Dbtr\>) side already supports a structured \<PstlAdr\> too — but the creditor side of a Direct Debit (pain.008 \<Cdtr\>) had no way to set or render \<PstlAdr\>. Some banks (e.g. Belgian banks) reject direct debit files that lack a structured creditor address, so this fills that gap.

  - PaymentInformation gains originStreetName, originBuildingNumber, originPostCode, originTownName, and originCountry, with setters/getters mirroring the existing origin* conventions (values run through the existing Sanitizer, country is upper-cased).
  - CustomerDirectDebitFacade::addPaymentInfo() accepts the new optional creditorStreetName, creditorBuildingNumber, creditorPostCode, creditorTownName, and creditorCountry keys and forwards them to the new setters.
  - CustomerDirectDebitTransferDomBuilder::visitPaymentInformation() now renders \<Cdtr\>\<PstlAdr\> when the message format is a direct debit at pain.008 version ≥ 2 (matching the existing rule for the debtor address), skipping StrtNm/BldgNb/PstCd/TwnNm on variants 2/3 (which only support Ctry/AdrLine), and only appending the 
 \<PstlAdr\> element if it ends up with at least one child.

  Test plan

  - [x] Added CustomerDirectDebitFacadeTest::testCreditorPostalAddressIsRendered(), which builds a direct debit via TransferFileFacadeFactory::createDirectDebit(), sets the new creditor fields through addPaymentInfo(), and asserts \<StrtNm\>, \<PstCd\>, \<TwnNm\>, and \<Ctry\> appear in the generated XML.
  - [x] composer phpstan — no errors
  - [x] composer phpcsfixer — no fixes needed
  - [x] composer phpunit — 602 tests, 1472 assertions, all green (1 pre-existing unrelated skip)
  
  Thank you